### PR TITLE
Add new_from_cipher() constructor to CtrAes*

### DIFF
--- a/aesni/src/ctr.rs
+++ b/aesni/src/ctr.rs
@@ -41,6 +41,15 @@ macro_rules! impl_ctr {
                 }
             }
 
+            pub fn new_from_cipher(cipher: $cipher, nonce: &[u8; BLOCK_SIZE]) -> Self {
+                let ctr = u64x2::read(nonce).swap_bytes();
+                Self{
+                    ctr, cipher,
+                    leftover_cursor: BLOCK_SIZE,
+                    leftover_buf: [0u8; BLOCK_SIZE]
+                }
+            }
+
             #[inline]
             pub fn xor(&mut self, mut buf: &mut [u8]) {
                 // process leftover bytes from the last call if any


### PR DESCRIPTION
This is the API I would prefer for instantiating `CtrAes*`. I already have my own wrappers for the `Aes*Ni` types that have done key expansion up front which I'd like to reuse to instantiate `CtrAes*` with.

Ideally I think this would be the type signature for `new` but I figured I'd go for a simple additive change first (especially as I'd like to start working off this branch in Miscreant)