### PR TITLE
Ctr trait

### DIFF
--- a/block-modes/src/ctr128.rs
+++ b/block-modes/src/ctr128.rs
@@ -1,8 +1,8 @@
 use block_cipher_trait::generic_array::{ArrayLength, GenericArray};
 use block_cipher_trait::generic_array::typenum::{U16, Unsigned};
 use block_cipher_trait::BlockCipher;
-use block_padding::Padding;
-use traits::{BlockMode, BlockModeError, BlockModeIv};
+use block_padding::{Padding, ZeroPadding};
+use traits::{BlockMode, BlockModeError, BlockModeIv, Ctr};
 use utils::xor;
 use core::mem;
 use core::marker::PhantomData;
@@ -95,4 +95,11 @@ where
     ) -> Result<(), BlockModeError> {
         self.encrypt_nopad(buffer)
     }
+}
+
+impl<C> Ctr<C> for Ctr128<C, ZeroPadding>
+where
+    C: BlockCipher<BlockSize = U16>,
+    C::ParBlocks: ArrayLength<GenericArray<u8, U16>>
+{
 }

--- a/block-modes/src/ctr64.rs
+++ b/block-modes/src/ctr64.rs
@@ -1,8 +1,8 @@
 use block_cipher_trait::generic_array::{ArrayLength, GenericArray};
 use block_cipher_trait::generic_array::typenum::{U8, Unsigned};
 use block_cipher_trait::BlockCipher;
-use block_padding::Padding;
-use traits::{BlockMode, BlockModeError, BlockModeIv};
+use block_padding::{Padding, ZeroPadding};
+use traits::{BlockMode, BlockModeError, BlockModeIv, Ctr};
 use utils::xor;
 use core::mem;
 use core::marker::PhantomData;
@@ -62,4 +62,11 @@ where
     ) -> Result<(), BlockModeError> {
         self.encrypt_nopad(buffer)
     }
+}
+
+impl<C> Ctr<C> for Ctr64<C, ZeroPadding>
+where
+    C: BlockCipher<BlockSize = U8>,
+    C::ParBlocks: ArrayLength<GenericArray<u8, U8>>
+{
 }


### PR DESCRIPTION
Provides an `xor()` method similar to the one(s) that used to exist in the aesni crate. Does not pad and handles messages which aren't aligned to the cipher's underlying block size.

Could definitely use some tests, but I thought I'd throw this up first as a strawman.