### PR TITLE
Add feature to disable aesni target feature compile time checks

### DIFF
--- a/aes/aesni/Cargo.toml
+++ b/aes/aesni/Cargo.toml
@@ -21,6 +21,7 @@ stream-cipher = { version = "0.1", features = ["dev"] }
 [features]
 default = ["ctr"]
 ctr = []
+nocheck = []
 
 [workspace]
 

--- a/aes/aesni/src/lib.rs
+++ b/aes/aesni/src/lib.rs
@@ -68,7 +68,7 @@ pub extern crate block_cipher_trait;
 #[macro_use] extern crate opaque_debug;
 #[cfg(feature = "ctr")]
 pub extern crate stream_cipher;
-
+#[cfg(not(feature = "nocheck"))]
 mod target_checks;
 #[macro_use]
 mod utils;


### PR DESCRIPTION
When using runtime `is_x86_feature_detected` macro to check if I could use aesni, I had to disable the checks.
Is it possible to include this little feature to allow usage of aesni without compile time checks?