### PR TITLE
Make blowfish generic over ByteOrder

### DIFF
--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["crypto", "blowfish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-byte-tools = "0.2"
 block-cipher-trait = "0.5"
+byteorder = { version = "1", default-features = false }
 opaque-debug = "0.1"
 
 [dev-dependencies]

--- a/blowfish/src/lib.rs
+++ b/blowfish/src/lib.rs
@@ -16,7 +16,6 @@ pub use byteorder::{BE, LE};
 
 mod consts;
 
-pub type BlowfishBE = Blowfish<BE>;
 pub type BlowfishLE = Blowfish<LE>;
 
 type Block = GenericArray<u8, U8>;


### PR DESCRIPTION
This should not break the public api if I'm not mistaken due to the default type parameter but I changed the dependencies so I'm not sure if thats a breaking change in a way.

Added the typedefs since something like that was mentioned in the issue. Not sure if they really are needed though cause one could just use the type parameters without adding many more characters.

Closes #26