### PR TITLE
Adds benches for Serpent + questions regarding optimization

### DIFF
--- a/serpent/benches/serpent.rs
+++ b/serpent/benches/serpent.rs
@@ -1,0 +1,9 @@
+#![no_std]
+#![feature(test)]
+#[macro_use]
+extern crate block_cipher_trait;
+extern crate serpent;
+
+use serpent::Serpent;
+
+bench!(Serpent, 16);

--- a/serpent/src/lib.rs
+++ b/serpent/src/lib.rs
@@ -28,9 +28,7 @@ pub struct Serpent {
     k: Subkeys,
 }
 
-fn get_bit(x: usize, i: usize) -> u8 {
-    (x >> i) as u8 & 0x01
-}
+fn get_bit(x: usize, i: usize) -> u8 { (x >> i) as u8 & 0x01 }
 
 fn linear_transform_bitslice(input: Block128, output: &mut Block128) {
     let mut words = [0u32; 4];
@@ -71,7 +69,8 @@ fn round_bitslice(
     b_i: Block128,
     k: Subkeys,
     b_output: &mut Block128,
-) {
+)
+{
     let xored_block = xor_block(b_i, k[i]);
 
     let s_i = apply_s_bitslice(i, xored_block);
@@ -87,7 +86,8 @@ fn round_inverse_bitslice(
     b_i_next: Block128,
     k: Subkeys,
     b_output: &mut Block128,
-) {
+)
+{
     let mut s_i = [0u8; 16];
     if i == ROUNDS - 1 {
         s_i = xor_block(b_i_next, k[ROUNDS]);
@@ -100,9 +100,7 @@ fn round_inverse_bitslice(
     *b_output = xor_block(xored, k[i]);
 }
 
-fn apply_s(index: usize, nibble: u8) -> u8 {
-    S[index % 8][nibble as usize]
-}
+fn apply_s(index: usize, nibble: u8) -> u8 { S[index % 8][nibble as usize] }
 fn apply_s_inverse(index: usize, nibble: u8) -> u8 {
     S_INVERSE[index % 8][nibble as usize]
 }
@@ -229,6 +227,7 @@ impl BlockCipher for Serpent {
         Self::new_varkey(key).unwrap()
     }
 
+    #[inline(always)]
     fn new_varkey(key: &[u8]) -> Result<Self, InvalidKeyLength> {
         if key.len() < 16 || key.len() > 32 {
             return Err(InvalidKeyLength);
@@ -240,6 +239,7 @@ impl BlockCipher for Serpent {
         })
     }
 
+    #[inline(always)]
     fn encrypt_block(&self, block: &mut GenericArray<u8, Self::BlockSize>) {
         let mut b = [0u8; 16];
 
@@ -253,6 +253,7 @@ impl BlockCipher for Serpent {
         *block = *GenericArray::from_slice(&b);
     }
 
+    #[inline(always)]
     fn decrypt_block(&self, block: &mut GenericArray<u8, Self::BlockSize>) {
         let mut b = [0u8; 16];
 

--- a/serpent/src/lib.rs
+++ b/serpent/src/lib.rs
@@ -64,13 +64,7 @@ fn linear_transform_inverse_bitslice(input: Block128, output: &mut Block128) {
     LE::write_u32_into(&words, output);
 }
 
-fn round_bitslice(
-    i: usize,
-    b_i: Block128,
-    k: Subkeys,
-    b_output: &mut Block128,
-)
-{
+fn round_bitslice(i: usize, b_i: Block128, k: Subkeys, b_output: &mut Block128) {
     let xored_block = xor_block(b_i, k[i]);
 
     let s_i = apply_s_bitslice(i, xored_block);
@@ -81,13 +75,9 @@ fn round_bitslice(
         linear_transform_bitslice(s_i, b_output);
     }
 }
-fn round_inverse_bitslice(
-    i: usize,
-    b_i_next: Block128,
-    k: Subkeys,
-    b_output: &mut Block128,
-)
-{
+
+#[allow(clippy::useless_let_if_seq)]
+fn round_inverse_bitslice(i: usize, b_i_next: Block128, k: Subkeys, b_output: &mut Block128) {
     let mut s_i = [0u8; 16];
     if i == ROUNDS - 1 {
         s_i = xor_block(b_i_next, k[ROUNDS]);
@@ -100,7 +90,10 @@ fn round_inverse_bitslice(
     *b_output = xor_block(xored, k[i]);
 }
 
-fn apply_s(index: usize, nibble: u8) -> u8 { S[index % 8][nibble as usize] }
+fn apply_s(index: usize, nibble: u8) -> u8 {
+    S[index % 8][nibble as usize]
+}
+
 fn apply_s_inverse(index: usize, nibble: u8) -> u8 {
     S_INVERSE[index % 8][nibble as usize]
 }

--- a/serpent/src/lib.rs
+++ b/serpent/src/lib.rs
@@ -227,7 +227,6 @@ impl BlockCipher for Serpent {
         Self::new_varkey(key).unwrap()
     }
 
-    #[inline(always)]
     fn new_varkey(key: &[u8]) -> Result<Self, InvalidKeyLength> {
         if key.len() < 16 || key.len() > 32 {
             return Err(InvalidKeyLength);
@@ -239,7 +238,6 @@ impl BlockCipher for Serpent {
         })
     }
 
-    #[inline(always)]
     fn encrypt_block(&self, block: &mut GenericArray<u8, Self::BlockSize>) {
         let mut b = [0u8; 16];
 
@@ -253,7 +251,6 @@ impl BlockCipher for Serpent {
         *block = *GenericArray::from_slice(&b);
     }
 
-    #[inline(always)]
     fn decrypt_block(&self, block: &mut GenericArray<u8, Self::BlockSize>) {
         let mut b = [0u8; 16];
 


### PR DESCRIPTION
I added benches for Serpent but results are not so satisfying, it could be x3-x10 better.

Here are the benchmark results :

```
running 2 tests
test decrypt ... bench:       8,447 ns/iter (+/- 200) = 1 MB/s
test encrypt ... bench:       8,325 ns/iter (+/- 676) = 1 MB/s
```

I have one simple question : could you guys provide some hints to improve the current Serpent implementation encrypt and decrypt speed? I don't mean Serpent specifics but more like Rust performance optimization such as `inline` and good practices.

Another question for you @tarcieri, earlier you told me about checking `branch instruction` on ASM, since I'm kinda newbie on this could you tell me what I have to consider regarding this?

Thanks!