### PR TITLE
Forbid unsafe code where possible

### DIFF
--- a/blowfish/src/lib.rs
+++ b/blowfish/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![forbid(unsafe_code)]
 pub extern crate block_cipher_trait;
 extern crate byteorder;
 #[macro_use] extern crate opaque_debug;

--- a/cast5/src/lib.rs
+++ b/cast5/src/lib.rs
@@ -23,6 +23,7 @@
 //! ```
 
 #![no_std]
+#![forbid(unsafe_code)]
 pub extern crate block_cipher_trait;
 extern crate byteorder;
 #[macro_use]

--- a/des/src/lib.rs
+++ b/des/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![forbid(unsafe_code)]
 pub extern crate block_cipher_trait;
 extern crate byteorder;
 #[macro_use] extern crate opaque_debug;
@@ -12,4 +13,3 @@ use block_cipher_trait::generic_array;
 
 pub use des::Des;
 pub use tdes::{TdesEde2, TdesEde3, TdesEee2, TdesEee3};
-

--- a/magma/src/lib.rs
+++ b/magma/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![forbid(unsafe_code)]
 pub extern crate block_cipher_trait;
 extern crate byteorder;
 #[macro_use] extern crate opaque_debug;

--- a/rc2/src/lib.rs
+++ b/rc2/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/RC2
 #![no_std]
+#![forbid(unsafe_code)]
 pub extern crate block_cipher_trait;
 #[macro_use] extern crate opaque_debug;
 

--- a/serpent/src/lib.rs
+++ b/serpent/src/lib.rs
@@ -4,6 +4,7 @@
 //! [2]: https://www.cl.cam.ac.uk/~fms27/serpent/
 //! [3]: https://github.com/efb9-860a-e752-0dac/serpent
 // #![no_std]
+#![forbid(unsafe_code)]
 pub extern crate block_cipher_trait;
 extern crate byteorder;
 #[macro_use]

--- a/twofish/src/lib.rs
+++ b/twofish/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![forbid(unsafe_code)]
 pub extern crate block_cipher_trait;
 extern crate byteorder;
 #[macro_use] extern crate opaque_debug;


### PR DESCRIPTION
`#![forbid(unsafe_code)]` attributes make rustc abort compilation if
there are any unsafe blocks in the crate, and exceptions cannot be made
with allow/warn attributes.

Also add badges on README.md to advertise the complete safety of the
changed crates ([rendered], tell me if it's too much i'll remove them).

[rendered]: https://github.com/hhirtz/block-ciphers/blob/blowfish-unsafe/README.md#supported-algorithms