### PR TITLE
aes: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,14 +6,14 @@ version = "0.3.2"
 dependencies = [
  "aes-soft 0.3.3",
  "aesni",
- "block-cipher-trait",
+ "block-cipher",
 ]
 
 [[package]]
 name = "aes-soft"
 version = "0.3.3"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]
@@ -33,7 +33,7 @@ dependencies = [
 name = "aesni"
 version = "0.6.0"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "opaque-debug",
  "stream-cipher",
 ]
@@ -48,13 +48,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-cipher"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/traits.git#9cfac08fc7c151122ddebd580e0754c240d23db2"
+dependencies = [
+ "blobby",
+ "generic-array 0.14.1",
+]
+
+[[package]]
 name = "block-cipher-trait"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 dependencies = [
  "blobby",
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -126,6 +135,15 @@ name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
 dependencies = [
  "typenum",
 ]
@@ -223,12 +241,11 @@ dependencies = [
 
 [[package]]
 name = "stream-cipher"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
+version = "0.4.0-pre"
+source = "git+https://github.com/RustCrypto/traits.git#9cfac08fc7c151122ddebd580e0754c240d23db2"
 dependencies = [
  "blobby",
- "generic-array",
+ "generic-array 0.14.1",
 ]
 
 [[package]]
@@ -237,7 +254,7 @@ version = "0.0.1"
 dependencies = [
  "block-cipher-trait",
  "byte-tools 0.1.3",
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ members = [
     "twofish",
     "threefish",
 ]
+
+[patch.crates-io]
+block-cipher = { git = "https://github.com/RustCrypto/traits.git" }
+stream-cipher = { git = "https://github.com/RustCrypto/traits.git" }

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -5,13 +5,14 @@ description = "Facade for AES (Rijndael) block ciphers implementations"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/aes"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "aes", "rijndael", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 
 [target.'cfg(not(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
 aes-soft = { version = "0.3", path = "aes-soft" }
@@ -20,4 +21,4 @@ aes-soft = { version = "0.3", path = "aes-soft" }
 aesni = { version = "0.6", default-features = false, path = "aesni" }
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "aes-soft"
 version = "0.3.3"
+description = "AES (Rijndael) block ciphers bit-sliced implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-description = "AES (Rijndael) block ciphers bit-sliced implementation"
+edition = "2018"
 documentation = "https://docs.rs/aes-soft"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "aes", "rijndael", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
 byteorder = { version = "1", default-features = false }
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "0.7.0-pre", features = ["dev"] }

--- a/aes/aes-soft/benches/aes128.rs
+++ b/aes/aes-soft/benches/aes128.rs
@@ -1,9 +1,8 @@
 #![no_std]
 #![feature(test)]
-extern crate aes_soft;
 extern crate test;
 
-use aes_soft::block_cipher_trait::BlockCipher;
+use aes_soft::block_cipher::{BlockCipher, NewBlockCipher};
 use aes_soft::Aes128;
 
 #[bench]

--- a/aes/aes-soft/benches/aes192.rs
+++ b/aes/aes-soft/benches/aes192.rs
@@ -1,9 +1,8 @@
 #![no_std]
 #![feature(test)]
-extern crate aes_soft;
 extern crate test;
 
-use aes_soft::block_cipher_trait::BlockCipher;
+use aes_soft::block_cipher::{BlockCipher, NewBlockCipher};
 use aes_soft::Aes192;
 
 #[bench]

--- a/aes/aes-soft/benches/aes256.rs
+++ b/aes/aes-soft/benches/aes256.rs
@@ -1,9 +1,8 @@
 #![no_std]
 #![feature(test)]
-extern crate aes_soft;
 extern crate test;
 
-use aes_soft::block_cipher_trait::BlockCipher;
+use aes_soft::block_cipher::{BlockCipher, NewBlockCipher};
 use aes_soft::Aes256;
 
 #[bench]

--- a/aes/aes-soft/src/bitslice.rs
+++ b/aes/aes-soft/src/bitslice.rs
@@ -1,9 +1,9 @@
-#![cfg_attr(feature="cargo-clippy", allow(unreadable_literal))]
+#![allow(clippy::many_single_char_names)]
 
+use crate::consts::U32X4_1;
+use crate::simd::u32x4;
 use byteorder::{ByteOrder, LE};
-use consts::U32X4_1;
 use core::ops::{BitAnd, BitXor, Not};
-use simd::u32x4;
 
 // This trait defines all of the operations needed for a type to be processed as part of an AES
 // encryption or decryption operation.

--- a/aes/aes-soft/src/consts.rs
+++ b/aes/aes-soft/src/consts.rs
@@ -1,6 +1,4 @@
-#![cfg_attr(feature="cargo-clippy", allow(unreadable_literal))]
-
-use simd::u32x4;
+use crate::simd::u32x4;
 
 pub const U32X4_0: u32x4 = u32x4(0, 0, 0, 0);
 pub const U32X4_1: u32x4 =

--- a/aes/aes-soft/src/expand.rs
+++ b/aes/aes-soft/src/expand.rs
@@ -1,9 +1,9 @@
-#![cfg_attr(feature="cargo-clippy", allow(unreadable_literal))]
+use block_cipher::generic_array::{ArrayLength, GenericArray};
 
-use block_cipher_trait::generic_array::{ArrayLength, GenericArray};
-
-use bitslice::{bit_slice_4x1_with_u16, un_bit_slice_4x1_with_u16, AesOps};
-use consts::RCON;
+use crate::bitslice::{
+    bit_slice_4x1_with_u16, un_bit_slice_4x1_with_u16, AesOps,
+};
+use crate::consts::RCON;
 
 fn ffmulx(x: u32) -> u32 {
     let m1: u32 = 0x80808080;

--- a/aes/aes-soft/src/lib.rs
+++ b/aes/aes-soft/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! # Usage example
 //! ```
-//! use aes_soft::block_cipher_trait::generic_array::GenericArray;
-//! use aes_soft::block_cipher_trait::BlockCipher;
+//! use aes_soft::block_cipher::generic_array::GenericArray;
+//! use aes_soft::block_cipher::{BlockCipher, NewBlockCipher};
 //! use aes_soft::Aes128;
 //!
 //! let key = GenericArray::from_slice(&[0u8; 16]);
@@ -32,9 +32,16 @@
 //! assert_eq!(block8, block8_copy);
 //! ```
 //! [1]: https://github.com/DaGenix/rust-crypto/blob/master/src/aessafe.rs
+
 #![no_std]
-pub extern crate block_cipher_trait;
-extern crate byteorder;
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub use block_cipher;
+
 #[macro_use]
 extern crate opaque_debug;
 
@@ -44,4 +51,4 @@ mod expand;
 mod impls;
 mod simd;
 
-pub use impls::{Aes128, Aes192, Aes256};
+pub use crate::impls::{Aes128, Aes192, Aes256};

--- a/aes/aes-soft/tests/lib.rs
+++ b/aes/aes-soft/tests/lib.rs
@@ -1,9 +1,9 @@
 //! Test vectors are from NESSIE:
 //! https://www.cosic.esat.kuleuven.be/nessie/testvectors/
 #![no_std]
-extern crate aes_soft;
+use aes_soft;
 #[macro_use]
-extern crate block_cipher_trait;
+extern crate block_cipher;
 
 new_test!(aes128_test, "aes128", aes_soft::Aes128);
 new_test!(aes192_test, "aes192", aes_soft::Aes192);

--- a/aes/aesni/Cargo.toml
+++ b/aes/aesni/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "aesni"
 version = "0.6.0"
+description = "AES (Rijndael) block ciphers implementation using AES-NI"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-description = "AES (Rijndael) block ciphers implementation using AES-NI"
+edition = "2018"
 documentation = "https://docs.rs/aesni"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "aes", "rijndael", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
-stream-cipher = { version = "0.3", optional = true }
+stream-cipher = { version = "0.4.0-pre", optional = true }
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
-stream-cipher = { version = "0.3", features = ["dev"] }
+block-cipher = { version = "0.7.0-pre", features = ["dev"] }
+stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
 
 [features]
 default = ["ctr"]

--- a/aes/aesni/benches/aes128.rs
+++ b/aes/aesni/benches/aes128.rs
@@ -1,10 +1,10 @@
 #![no_std]
 #![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #![feature(test)]
-extern crate aesni;
+
 extern crate test;
 
-use aesni::block_cipher_trait::BlockCipher;
+use aesni::block_cipher::{BlockCipher, NewBlockCipher};
 use aesni::Aes128;
 
 #[bench]

--- a/aes/aesni/benches/aes128_ctr.rs
+++ b/aes/aesni/benches/aes128_ctr.rs
@@ -2,6 +2,6 @@
 #![feature(test)]
 #[macro_use]
 extern crate stream_cipher;
-extern crate aesni;
+use aesni;
 
 bench_sync!(aesni::Aes128Ctr);

--- a/aes/aesni/benches/aes192.rs
+++ b/aes/aesni/benches/aes192.rs
@@ -1,10 +1,10 @@
 #![no_std]
 #![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #![feature(test)]
-extern crate aesni;
+
 extern crate test;
 
-use aesni::block_cipher_trait::BlockCipher;
+use aesni::block_cipher::{BlockCipher, NewBlockCipher};
 use aesni::Aes192;
 
 #[bench]

--- a/aes/aesni/benches/aes192_ctr.rs
+++ b/aes/aesni/benches/aes192_ctr.rs
@@ -2,6 +2,6 @@
 #![feature(test)]
 #[macro_use]
 extern crate stream_cipher;
-extern crate aesni;
+use aesni;
 
 bench_sync!(aesni::Aes192Ctr);

--- a/aes/aesni/benches/aes256.rs
+++ b/aes/aesni/benches/aes256.rs
@@ -1,10 +1,10 @@
 #![no_std]
 #![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #![feature(test)]
-extern crate aesni;
+
 extern crate test;
 
-use aesni::block_cipher_trait::BlockCipher;
+use aesni::block_cipher::{BlockCipher, NewBlockCipher};
 use aesni::Aes256;
 
 #[bench]

--- a/aes/aesni/benches/aes256_ctr.rs
+++ b/aes/aesni/benches/aes256_ctr.rs
@@ -2,6 +2,6 @@
 #![feature(test)]
 #[macro_use]
 extern crate stream_cipher;
-extern crate aesni;
+use aesni;
 
 bench_sync!(aesni::Aes256Ctr);

--- a/aes/aesni/src/aes128/expand.rs
+++ b/aes/aesni/src/aes128/expand.rs
@@ -1,6 +1,6 @@
-use arch::*;
+use crate::arch::*;
 
-use core::mem;
+use core::mem::MaybeUninit;
 
 macro_rules! expand_round {
     ($enc_keys:expr, $dec_keys:expr, $pos:expr, $round:expr) => {
@@ -27,8 +27,8 @@ macro_rules! expand_round {
 #[inline(always)]
 pub(super) fn expand(key: &[u8; 16]) -> ([__m128i; 11], [__m128i; 11]) {
     unsafe {
-        let mut enc_keys: [__m128i; 11] = mem::uninitialized();
-        let mut dec_keys: [__m128i; 11] = mem::uninitialized();
+        let mut enc_keys: [__m128i; 11] = MaybeUninit::uninit().assume_init();
+        let mut dec_keys: [__m128i; 11] = MaybeUninit::uninit().assume_init();
 
         let k = _mm_loadu_si128(key.as_ptr() as *const __m128i);
         _mm_store_si128(enc_keys.as_mut_ptr(), k);

--- a/aes/aesni/src/aes128/test_expand.rs
+++ b/aes/aesni/src/aes128/test_expand.rs
@@ -1,5 +1,5 @@
 use super::expand::expand;
-use utils::check;
+use crate::utils::check;
 
 #[test]
 fn test() {

--- a/aes/aesni/src/aes192/expand.rs
+++ b/aes/aesni/src/aes192/expand.rs
@@ -1,6 +1,7 @@
-use arch::*;
+use crate::arch::*;
 
-use core::{mem, ptr};
+use core::mem::{self, MaybeUninit};
+use core::ptr;
 
 macro_rules! expand_round {
     ($t1:expr, $t3:expr, $round:expr) => {{
@@ -40,8 +41,8 @@ macro_rules! shuffle {
 #[inline(always)]
 pub(super) fn expand(key: &[u8; 24]) -> ([__m128i; 13], [__m128i; 13]) {
     unsafe {
-        let mut enc_keys: [__m128i; 13] = mem::uninitialized();
-        let mut dec_keys: [__m128i; 13] = mem::uninitialized();
+        let mut enc_keys: [__m128i; 13] = MaybeUninit::uninit().assume_init();
+        let mut dec_keys: [__m128i; 13] = MaybeUninit::uninit().assume_init();
 
         macro_rules! store {
             ($i:expr, $k:expr) => {

--- a/aes/aesni/src/aes192/test_expand.rs
+++ b/aes/aesni/src/aes192/test_expand.rs
@@ -1,5 +1,5 @@
 use super::expand::expand;
-use utils::check;
+use crate::utils::check;
 
 #[test]
 fn test() {

--- a/aes/aesni/src/aes256/expand.rs
+++ b/aes/aesni/src/aes256/expand.rs
@@ -1,6 +1,6 @@
-use arch::*;
+use crate::arch::*;
 
-use core::mem;
+use core::mem::MaybeUninit;
 
 macro_rules! expand_round {
     ($enc_keys:expr, $dec_keys:expr, $pos:expr, $round:expr) => {
@@ -64,8 +64,8 @@ macro_rules! expand_round_last {
 #[inline(always)]
 pub(super) fn expand(key: &[u8; 32]) -> ([__m128i; 15], [__m128i; 15]) {
     unsafe {
-        let mut enc_keys: [__m128i; 15] = mem::uninitialized();
-        let mut dec_keys: [__m128i; 15] = mem::uninitialized();
+        let mut enc_keys: [__m128i; 15] = MaybeUninit::uninit().assume_init();
+        let mut dec_keys: [__m128i; 15] = MaybeUninit::uninit().assume_init();
 
         let kp = key.as_ptr() as *const __m128i;
         let k1 = _mm_loadu_si128(kp);

--- a/aes/aesni/src/aes256/test_expand.rs
+++ b/aes/aesni/src/aes256/test_expand.rs
@@ -1,5 +1,5 @@
 use super::expand::expand;
-use utils::check;
+use crate::utils::check;
 
 #[test]
 fn test() {

--- a/aes/aesni/src/ctr.rs
+++ b/aes/aesni/src/ctr.rs
@@ -1,10 +1,11 @@
-use arch::*;
-use core::{cmp, mem};
+use crate::arch::*;
+use core::cmp;
+use core::mem::{self, MaybeUninit};
 
 use super::{Aes128, Aes192, Aes256};
-use block_cipher_trait::generic_array::typenum::U16;
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+use block_cipher::generic_array::typenum::U16;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::NewBlockCipher;
 use stream_cipher::{
     LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek,
 };
@@ -84,7 +85,7 @@ macro_rules! impl_ctr {
             #[inline(always)]
             fn next_block8(&mut self) -> [__m128i; 8] {
                 let mut ctr = self.ctr;
-                let mut block8: [__m128i; 8] = unsafe { mem::uninitialized() };
+                let mut block8: [__m128i; 8] = unsafe { MaybeUninit::uninit().assume_init() };
                 for i in 0..8 {
                     block8[i] = swap_bytes(ctr);
                     ctr = inc_be(ctr);
@@ -122,7 +123,7 @@ macro_rules! impl_ctr {
         }
 
         impl NewStreamCipher for $name {
-            type KeySize = <$cipher as BlockCipher>::KeySize;
+            type KeySize = <$cipher as NewBlockCipher>::KeySize;
             type NonceSize = U16;
 
             fn new(

--- a/aes/aesni/src/lib.rs
+++ b/aes/aesni/src/lib.rs
@@ -34,8 +34,8 @@
 //!
 //! # Usage example
 //! ```
-//! use aesni::block_cipher_trait::generic_array::GenericArray;
-//! use aesni::block_cipher_trait::BlockCipher;
+//! use aesni::block_cipher::generic_array::GenericArray;
+//! use aesni::block_cipher::{BlockCipher, NewBlockCipher};
 //! use aesni::Aes128;
 //!
 //! let key = GenericArray::from_slice(&[0u8; 16]);
@@ -70,8 +70,14 @@
 //!
 //! - [Intel AES-NI whitepaper](https://software.intel.com/sites/default/files/article/165683/aes-wp-2012-09-22-v01.pdf)
 //! - [Use of the AES Instruction Set](https://www.cosic.esat.kuleuven.be/ecrypt/AESday/slides/Use_of_the_AES_Instruction_Set.pdf)
+
 #![no_std]
-pub extern crate block_cipher_trait;
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub use block_cipher;
 #[macro_use]
 extern crate opaque_debug;
 #[cfg(feature = "ctr")]
@@ -91,9 +97,9 @@ use core::arch::x86 as arch;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64 as arch;
 
-pub use aes128::Aes128;
-pub use aes192::Aes192;
-pub use aes256::Aes256;
+pub use crate::aes128::Aes128;
+pub use crate::aes192::Aes192;
+pub use crate::aes256::Aes256;
 
 #[cfg(feature = "ctr")]
-pub use ctr::{Aes128Ctr, Aes192Ctr, Aes256Ctr};
+pub use crate::ctr::{Aes128Ctr, Aes192Ctr, Aes256Ctr};

--- a/aes/aesni/src/utils.rs
+++ b/aes/aesni/src/utils.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
-use arch::__m128i;
+use crate::arch::__m128i;
 #[cfg(test)]
 use core::mem;
 
-use block_cipher_trait::generic_array::typenum::{U16, U8};
-use block_cipher_trait::generic_array::GenericArray;
+use block_cipher::generic_array::typenum::{U16, U8};
+use block_cipher::generic_array::GenericArray;
 
 pub type Block128 = GenericArray<u8, U16>;
 pub type Block128x8 = GenericArray<GenericArray<u8, U16>, U8>;

--- a/aes/aesni/tests/ctr.rs
+++ b/aes/aesni/tests/ctr.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "ctr")]
-extern crate aesni;
+
 #[macro_use]
 extern crate stream_cipher;
 

--- a/aes/aesni/tests/lib.rs
+++ b/aes/aesni/tests/lib.rs
@@ -2,9 +2,9 @@
 //! https://www.cosic.esat.kuleuven.be/nessie/testvectors/
 #![no_std]
 #![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-extern crate aesni;
+use aesni;
 #[macro_use]
-extern crate block_cipher_trait;
+extern crate block_cipher;
 
 new_test!(aes128_test, "aes128", aesni::Aes128);
 new_test!(aes192_test, "aes192", aesni::Aes192);

--- a/aes/benches/aes128.rs
+++ b/aes/benches/aes128.rs
@@ -1,9 +1,9 @@
 #![no_std]
 #![feature(test)]
-extern crate aes;
+
 extern crate test;
 
-use aes::{Aes128, BlockCipher};
+use aes::{Aes128, BlockCipher, NewBlockCipher};
 
 #[bench]
 pub fn aes128_encrypt(bh: &mut test::Bencher) {

--- a/aes/benches/aes192.rs
+++ b/aes/benches/aes192.rs
@@ -1,9 +1,9 @@
 #![no_std]
 #![feature(test)]
-extern crate aes;
+
 extern crate test;
 
-use aes::{Aes192, BlockCipher};
+use aes::{Aes192, BlockCipher, NewBlockCipher};
 
 #[bench]
 pub fn aes192_encrypt(bh: &mut test::Bencher) {

--- a/aes/benches/aes256.rs
+++ b/aes/benches/aes256.rs
@@ -1,9 +1,9 @@
 #![no_std]
 #![feature(test)]
-extern crate aes;
+
 extern crate test;
 
-use aes::{Aes256, BlockCipher};
+use aes::{Aes256, BlockCipher, NewBlockCipher};
 
 #[bench]
 pub fn aes256_encrypt(bh: &mut test::Bencher) {

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -13,8 +13,8 @@
 //!
 //! # Usage example
 //! ```
-//! use aes::block_cipher_trait::generic_array::GenericArray;
-//! use aes::block_cipher_trait::BlockCipher;
+//! use aes::block_cipher::generic_array::GenericArray;
+//! use aes::block_cipher::{BlockCipher, NewBlockCipher};
 //! use aes::Aes128;
 //!
 //! let key = GenericArray::from_slice(&[0u8; 16]);
@@ -40,14 +40,16 @@
 //!
 //! For implementations of block cipher modes of operation see
 //! [`block-modes`](https://docs.rs/block-modes) crate.
+
 #![no_std]
-#[cfg(not(all(
-    target_feature = "aes",
-    target_feature = "sse2",
-    any(target_arch = "x86_64", target_arch = "x86"),
-)))]
-extern crate aes_soft;
-pub extern crate block_cipher_trait;
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub use block_cipher::{self, BlockCipher, NewBlockCipher};
+
 #[cfg(not(all(
     target_feature = "aes",
     target_feature = "sse2",
@@ -55,12 +57,6 @@ pub extern crate block_cipher_trait;
 )))]
 pub use aes_soft::{Aes128, Aes192, Aes256};
 
-#[cfg(all(
-    target_feature = "aes",
-    target_feature = "sse2",
-    any(target_arch = "x86_64", target_arch = "x86"),
-))]
-extern crate aesni;
 #[cfg(all(
     target_feature = "aes",
     target_feature = "sse2",

--- a/aes/tests/lib.rs
+++ b/aes/tests/lib.rs
@@ -1,9 +1,9 @@
 //! Test vectors are from NESSIE:
 //! https://www.cosic.esat.kuleuven.be/nessie/testvectors/
 #![no_std]
-extern crate aes;
+use aes;
 #[macro_use]
-extern crate block_cipher_trait;
+extern crate block_cipher;
 
 new_test!(aes128_test, "aes128", aes::Aes128);
 new_test!(aes192_test, "aes192", aes::Aes192);


### PR DESCRIPTION
Upgrades the `aes`, `aes-soft`, and `aesni` crates to Rust 2018 edition.

Additionally upgrades them to the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).