### PR TITLE
block-modes: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@
 name = "aes"
 version = "0.3.2"
 dependencies = [
- "aes-soft 0.3.3",
+ "aes-soft",
  "aesni",
  "block-cipher",
 ]
@@ -14,17 +14,6 @@ name = "aes-soft"
 version = "0.3.3"
 dependencies = [
  "block-cipher",
- "byteorder",
- "opaque-debug",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
-dependencies = [
- "block-cipher-trait",
  "byteorder",
  "opaque-debug",
 ]
@@ -70,8 +59,8 @@ dependencies = [
 name = "block-modes"
 version = "0.3.3"
 dependencies = [
- "aes-soft 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "block-cipher-trait",
+ "aes-soft",
+ "block-cipher",
  "block-padding",
  "hex-literal",
 ]

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -5,16 +5,17 @@ description = "Block cipher modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/block-modes"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "block-cipher", "ciphers"]
 
 [dependencies]
 block-padding = "0.1"
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 
 [dev-dependencies]
-aes-soft = "0.3"
+aes-soft = { version = "0.3", path = "../aes/aes-soft" }
 hex-literal = "0.1"
 
 [features]

--- a/block-modes/src/ecb.rs
+++ b/block-modes/src/ecb.rs
@@ -1,10 +1,10 @@
-use block_cipher_trait::generic_array::typenum::Unsigned;
-use block_cipher_trait::BlockCipher;
+use crate::errors::InvalidKeyIvLength;
+use crate::traits::BlockMode;
+use crate::utils::{get_par_blocks, Block};
+use block_cipher::generic_array::typenum::Unsigned;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use block_padding::Padding;
 use core::marker::PhantomData;
-use errors::InvalidKeyIvLength;
-use traits::BlockMode;
-use utils::{get_par_blocks, Block};
 
 /// [Electronic Codebook][1] (ECB) block cipher mode instance.
 ///
@@ -12,12 +12,16 @@ use utils::{get_par_blocks, Block};
 /// just pass `Default::default()` instead.
 ///
 /// [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#ECB
-pub struct Ecb<C: BlockCipher, P: Padding> {
+pub struct Ecb<C: BlockCipher + BlockCipher, P: Padding> {
     cipher: C,
     _p: PhantomData<P>,
 }
 
-impl<C: BlockCipher, P: Padding> BlockMode<C, P> for Ecb<C, P> {
+impl<C, P> BlockMode<C, P> for Ecb<C, P>
+where
+    C: BlockCipher + NewBlockCipher,
+    P: Padding,
+{
     fn new(cipher: C, _iv: &Block<C>) -> Self {
         Self {
             cipher,

--- a/block-modes/src/errors.rs
+++ b/block-modes/src/errors.rs
@@ -11,7 +11,7 @@ pub struct BlockModeError;
 pub struct InvalidKeyIvLength;
 
 impl fmt::Display for BlockModeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_str("BlockModeError")
     }
 }
@@ -24,7 +24,7 @@ impl error::Error for BlockModeError {
 }
 
 impl fmt::Display for InvalidKeyIvLength {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_str("InvalidKeyIvLength")
     }
 }

--- a/block-modes/src/lib.rs
+++ b/block-modes/src/lib.rs
@@ -8,9 +8,7 @@
 //! # Usage example
 //! ```
 //! #[macro_use] extern crate hex_literal;
-//! extern crate aes_soft as aes;
-//! extern crate block_modes;
-//!
+//! # use aes_soft as aes;
 //! use block_modes::{BlockMode, Cbc};
 //! use block_modes::block_padding::Pkcs7;
 //! use aes::Aes128;
@@ -46,9 +44,7 @@
 //! `encrypt_vec` and `descrypt_vec` methods:
 //! ```
 //! # #[macro_use] extern crate hex_literal;
-//! # extern crate aes_soft as aes;
-//! # extern crate block_modes;
-//! #
+//! # use aes_soft as aes;
 //! # use block_modes::{BlockMode, Cbc};
 //! # use block_modes::block_padding::Pkcs7;
 //! # use aes::Aes128;
@@ -74,21 +70,27 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation
 //! [2]: https://github.com/RustCrypto/stream-ciphers
+
 #![no_std]
-extern crate block_cipher_trait;
-pub extern crate block_padding;
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub use block_padding;
 #[cfg(feature = "std")]
 extern crate std;
 
 mod errors;
 mod traits;
 mod utils;
-pub use errors::{BlockModeError, InvalidKeyIvLength};
-pub use traits::BlockMode;
+pub use crate::errors::{BlockModeError, InvalidKeyIvLength};
+pub use crate::traits::BlockMode;
 
 mod cbc;
-pub use cbc::Cbc;
+pub use crate::cbc::Cbc;
 mod ecb;
-pub use ecb::Ecb;
+pub use crate::ecb::Ecb;
 mod pcbc;
-pub use pcbc::Pcbc;
+pub use crate::pcbc::Pcbc;

--- a/block-modes/src/pcbc.rs
+++ b/block-modes/src/pcbc.rs
@@ -1,20 +1,25 @@
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+use crate::traits::BlockMode;
+use crate::utils::{xor, Block};
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use block_padding::Padding;
 use core::marker::PhantomData;
-use traits::BlockMode;
-use utils::{xor, Block};
 
 /// [Propagating Cipher Block Chaining][1] (PCBC) mode instance.
 ///
 /// [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#PCBC
-pub struct Pcbc<C: BlockCipher, P: Padding> {
+pub struct Pcbc<C: BlockCipher + NewBlockCipher, P: Padding> {
     cipher: C,
     iv: GenericArray<u8, C::BlockSize>,
     _p: PhantomData<P>,
 }
 
-impl<C: BlockCipher, P: Padding> Pcbc<C, P> {
+impl<C, P> Pcbc<C, P>
+where
+    C: BlockCipher + NewBlockCipher,
+    P: Padding,
+{
+    /// Initialize PCBC
     pub fn new(cipher: C, iv: &Block<C>) -> Self {
         Self {
             cipher,
@@ -24,7 +29,11 @@ impl<C: BlockCipher, P: Padding> Pcbc<C, P> {
     }
 }
 
-impl<C: BlockCipher, P: Padding> BlockMode<C, P> for Pcbc<C, P> {
+impl<C, P> BlockMode<C, P> for Pcbc<C, P>
+where
+    C: BlockCipher + NewBlockCipher,
+    P: Padding,
+{
     fn new(cipher: C, iv: &GenericArray<u8, C::BlockSize>) -> Self {
         Self {
             cipher,

--- a/block-modes/src/traits.rs
+++ b/block-modes/src/traits.rs
@@ -1,16 +1,20 @@
 #[cfg(feature = "std")]
 pub use std::vec::Vec;
 
-use block_cipher_trait::generic_array::typenum::Unsigned;
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+use crate::errors::{BlockModeError, InvalidKeyIvLength};
+use crate::utils::{to_blocks, Block, Key};
+use block_cipher::generic_array::typenum::Unsigned;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use block_padding::Padding;
-use errors::{BlockModeError, InvalidKeyIvLength};
-use utils::{to_blocks, Block, Key};
 
 /// Trait for a block cipher mode of operation that is used to apply a block cipher
 /// operation to input data to transform it into a variable-length output message.
-pub trait BlockMode<C: BlockCipher, P: Padding>: Sized {
+pub trait BlockMode<C, P>: Sized
+where
+    C: BlockCipher + NewBlockCipher,
+    P: Padding,
+{
     /// Create a new block mode instance from initialized block cipher and IV.
     fn new(cipher: C, iv: &Block<C>) -> Self;
 

--- a/block-modes/src/utils.rs
+++ b/block-modes/src/utils.rs
@@ -1,7 +1,6 @@
-use block_cipher_trait::generic_array::typenum::Unsigned;
-use block_cipher_trait::generic_array::ArrayLength;
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+use block_cipher::generic_array::typenum::Unsigned;
+use block_cipher::generic_array::{ArrayLength, GenericArray};
+use block_cipher::{BlockCipher, NewBlockCipher};
 use core::slice;
 
 #[inline(always)]
@@ -12,7 +11,7 @@ pub fn xor(buf: &mut [u8], key: &[u8]) {
     }
 }
 
-pub(crate) type Key<C> = GenericArray<u8, <C as BlockCipher>::KeySize>;
+pub(crate) type Key<C> = GenericArray<u8, <C as NewBlockCipher>::KeySize>;
 pub(crate) type Block<C> = GenericArray<u8, <C as BlockCipher>::BlockSize>;
 pub(crate) type ParBlocks<C> =
     GenericArray<Block<C>, <C as BlockCipher>::ParBlocks>;
@@ -23,6 +22,8 @@ where
 {
     let n = N::to_usize();
     debug_assert!(data.len() % n == 0);
+
+    #[allow(unsafe_code)]
     unsafe {
         slice::from_raw_parts_mut(
             data.as_ptr() as *mut GenericArray<u8, N>,
@@ -38,6 +39,8 @@ pub(crate) fn get_par_blocks<C: BlockCipher>(
     let n_par = blocks.len() / pb;
 
     let (par, single) = blocks.split_at_mut(n_par * pb);
+
+    #[allow(unsafe_code)]
     let par = unsafe {
         slice::from_raw_parts_mut(par.as_ptr() as *mut ParBlocks<C>, n_par)
     };

--- a/block-modes/tests/lib.rs
+++ b/block-modes/tests/lib.rs
@@ -1,7 +1,4 @@
 //! Test vectors generated with OpenSSL
-extern crate aes_soft;
-extern crate block_cipher_trait;
-extern crate block_modes;
 
 use aes_soft::Aes128;
 use block_modes::block_padding::ZeroPadding;


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).