### PR TITLE
blowfish: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 name = "blowfish"
 version = "0.4.0"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]

--- a/block-modes/src/lib.rs
+++ b/block-modes/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! # Usage example
 //! ```
-//! #[macro_use] extern crate hex_literal;
+//! # #[macro_use] extern crate hex_literal;
 //! # use aes_soft as aes;
 //! use block_modes::{BlockMode, Cbc};
 //! use block_modes::block_padding::Pkcs7;

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -5,18 +5,19 @@ description = "Blowfish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/blowfish"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "blowfish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 byteorder = { version = "1", default-features = false }
 opaque-debug = "0.2"
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [features]
 bcrypt = []

--- a/blowfish/benches/lib.rs
+++ b/blowfish/benches/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(test)]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate blowfish;
+extern crate block_cipher;
+use blowfish;
 
 bench!(blowfish::Blowfish, 16);

--- a/blowfish/src/lib.rs
+++ b/blowfish/src/lib.rs
@@ -1,16 +1,23 @@
+//! Blowfish block cipher
+
 #![no_std]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
 #![forbid(unsafe_code)]
-pub extern crate block_cipher_trait;
-extern crate byteorder;
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub use block_cipher;
+
 #[macro_use]
 extern crate opaque_debug;
 
 use core::marker::PhantomData;
 
-use block_cipher_trait::generic_array::typenum::{U1, U56, U8};
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
-use block_cipher_trait::InvalidKeyLength;
+use block_cipher::generic_array::typenum::{U1, U56, U8};
+use block_cipher::generic_array::GenericArray;
+use block_cipher::InvalidKeyLength;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use byteorder::ByteOrder;
 use byteorder::{BE, LE};
 
@@ -103,10 +110,8 @@ impl<T: ByteOrder> Blowfish<T> {
     }
 }
 
-impl<T: ByteOrder> BlockCipher for Blowfish<T> {
+impl<T: ByteOrder> NewBlockCipher for Blowfish<T> {
     type KeySize = U56;
-    type BlockSize = U8;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U56>) -> Self {
         Self::new_varkey(&key).unwrap()
@@ -120,6 +125,11 @@ impl<T: ByteOrder> BlockCipher for Blowfish<T> {
         blowfish.expand_key(key);
         Ok(blowfish)
     }
+}
+
+impl<T: ByteOrder> BlockCipher for Blowfish<T> {
+    type BlockSize = U8;
+    type ParBlocks = U1;
 
     #[inline]
     fn encrypt_block(&self, block: &mut Block) {

--- a/blowfish/tests/lib.rs
+++ b/blowfish/tests/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate blowfish;
+extern crate block_cipher;
+use blowfish;
 
 new_test!(blowfish_test, "blowfish", blowfish::Blowfish);


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).