### PR TITLE
cast5: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 name = "cast5"
 version = "0.6.0"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -5,18 +5,19 @@ description = "CAST5 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/cast5"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "cast5", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
 byteorder = { version = "1", default-features = false }
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [features]
 default = []

--- a/cast5/benches/lib.rs
+++ b/cast5/benches/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(test)]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate cast5;
+extern crate block_cipher;
+use cast5;
 
 bench!(cast5::Cast5, 16);

--- a/cast5/src/cast5.rs
+++ b/cast5/src/cast5.rs
@@ -1,14 +1,15 @@
-use block_cipher_trait::generic_array::typenum::{U1, U16, U8};
-use block_cipher_trait::generic_array::GenericArray;
+use block_cipher::generic_array::typenum::{U1, U16, U8};
+use block_cipher::generic_array::GenericArray;
 
-use block_cipher_trait::{BlockCipher, InvalidKeyLength};
+use block_cipher::{BlockCipher, InvalidKeyLength, NewBlockCipher};
 use byteorder::{BigEndian, ByteOrder};
 
-use consts::*;
-use schedule::key_schedule;
+use crate::consts::*;
+use crate::schedule::key_schedule;
 
 type Block = GenericArray<u8, U8>;
 
+/// The CAST5 block cipher.
 #[derive(Clone, Copy)]
 pub struct Cast5 {
     masking: [u32; 16],
@@ -77,10 +78,8 @@ macro_rules! f3 {
     }};
 }
 
-impl BlockCipher for Cast5 {
+impl NewBlockCipher for Cast5 {
     type KeySize = U16;
-    type BlockSize = U8;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U16>) -> Self {
         Self::new_varkey(&key).unwrap()
@@ -103,6 +102,11 @@ impl BlockCipher for Cast5 {
         }
         Ok(cast5)
     }
+}
+
+impl BlockCipher for Cast5 {
+    type BlockSize = U8;
+    type ParBlocks = U1;
 
     #[inline]
     fn encrypt_block(&self, block: &mut Block) {

--- a/cast5/src/lib.rs
+++ b/cast5/src/lib.rs
@@ -5,8 +5,8 @@
 //!
 //! # Usage example
 //! ```
-//! use cast5::block_cipher_trait::generic_array::GenericArray;
-//! use cast5::block_cipher_trait::BlockCipher;
+//! use cast5::block_cipher::generic_array::GenericArray;
+//! use cast5::block_cipher::{BlockCipher, NewBlockCipher};
 //! use cast5::Cast5;
 //!
 //! let key = GenericArray::from_slice(&[0u8; 16]);
@@ -22,17 +22,22 @@
 //! assert_eq!(block, block_copy);
 //! ```
 
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
 #![no_std]
 #![forbid(unsafe_code)]
-pub extern crate block_cipher_trait;
-extern crate byteorder;
+pub use block_cipher;
+
 #[macro_use]
 extern crate opaque_debug;
 
-pub use block_cipher_trait::BlockCipher;
+pub use block_cipher::BlockCipher;
 
 mod cast5;
 mod consts;
 mod schedule;
 
-pub use cast5::Cast5;
+pub use crate::cast5::Cast5;

--- a/cast5/src/schedule.rs
+++ b/cast5/src/schedule.rs
@@ -1,4 +1,4 @@
-use consts::*;
+use crate::consts::*;
 
 macro_rules! get_i {
     ($x:expr, $i:expr) => {

--- a/cast5/tests/lib.rs
+++ b/cast5/tests/lib.rs
@@ -1,10 +1,10 @@
 #![no_std]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate cast5;
+extern crate block_cipher;
+use cast5;
 
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use cast5::Cast5;
 
 #[test]


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).