### PR TITLE
des: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 name = "des"
 version = "0.3.0"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]

--- a/cast5/src/lib.rs
+++ b/cast5/src/lib.rs
@@ -22,13 +22,13 @@
 //! assert_eq!(block, block_copy);
 //! ```
 
+#![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
 )]
-#![deny(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
-#![no_std]
 #![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
 pub use block_cipher;
 
 #[macro_use]

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,21 +1,23 @@
 [package]
 name = "des"
 version = "0.3.0"
+description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"
-description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
+readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/des"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "des", "tdes", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 byteorder = { version = "1", default-features = false }
 opaque-debug = "0.2"
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [badges]
 travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/des/README.md
+++ b/des/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: Data Encryption Standard (DES)
+# RustCrypto: Data Encryption Standard (DES) and 3DES
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -7,7 +7,7 @@
 [![Build Status][build-image]][build-link]
 [![HAZMAT][hazmat-image]][hazmat-link]
 
-Pure Rust implementation of the [DES cipher][1].
+Pure Rust implementation of the [DES cipher][1], including triple DES (3DES).
 
 [Documentation][docs-link]
 

--- a/des/benches/des.rs
+++ b/des/benches/des.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(test)]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate des;
+extern crate block_cipher;
+use des;
 
 bench!(des::Des, 8);

--- a/des/benches/tdes.rs
+++ b/des/benches/tdes.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(test)]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate des;
+extern crate block_cipher;
+use des;
 
 bench!(des::TdesEde3, 24);

--- a/des/src/des.rs
+++ b/des/src/des.rs
@@ -1,10 +1,13 @@
-use super::BlockCipher;
+//! Data Encryption Standard (DES) block cipher.
+
+use crate::generic_array::typenum::{U1, U8};
+use crate::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use byteorder::{ByteOrder, BE};
-use generic_array::typenum::{U1, U8};
-use generic_array::GenericArray;
 
-use consts::{SBOXES, SHIFTS};
+use crate::consts::{SBOXES, SHIFTS};
 
+/// Data Encryption Standard (DES) block cipher.
 #[derive(Copy, Clone)]
 pub struct Des {
     pub(crate) keys: [u64; 16],
@@ -187,16 +190,19 @@ impl Des {
     }
 }
 
-impl BlockCipher for Des {
+impl NewBlockCipher for Des {
     type KeySize = U8;
-    type BlockSize = U8;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U8>) -> Self {
         Des {
             keys: gen_keys(BE::read_u64(key)),
         }
     }
+}
+
+impl BlockCipher for Des {
+    type BlockSize = U8;
+    type ParBlocks = U1;
 
     fn encrypt_block(&self, block: &mut GenericArray<u8, U8>) {
         let data = BE::read_u64(block);

--- a/des/src/lib.rs
+++ b/des/src/lib.rs
@@ -1,7 +1,16 @@
+//! Pure Rust implementation of the [DES cipher][1], including triple DES (3DES).
+//!
+//! [1]: https://en.wikipedia.org/wiki/Data_Encryption_Standard
+
 #![no_std]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
 #![forbid(unsafe_code)]
-pub extern crate block_cipher_trait;
-extern crate byteorder;
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub use block_cipher;
+
 #[macro_use]
 extern crate opaque_debug;
 
@@ -9,8 +18,7 @@ mod consts;
 mod des;
 mod tdes;
 
-use block_cipher_trait::generic_array;
-use block_cipher_trait::BlockCipher;
+use block_cipher::generic_array;
 
-pub use des::Des;
-pub use tdes::{TdesEde2, TdesEde3, TdesEee2, TdesEee3};
+pub use crate::des::Des;
+pub use crate::tdes::{TdesEde2, TdesEde3, TdesEee2, TdesEee3};

--- a/des/src/tdes.rs
+++ b/des/src/tdes.rs
@@ -1,10 +1,13 @@
-use super::BlockCipher;
-use des::{gen_keys, Des};
+//! Triple DES (3DES) block cipher.
 
+use crate::des::{gen_keys, Des};
+use block_cipher::{BlockCipher, NewBlockCipher};
+
+use crate::generic_array::typenum::{U1, U16, U24, U8};
+use crate::generic_array::GenericArray;
 use byteorder::{ByteOrder, BE};
-use generic_array::typenum::{U1, U16, U24, U8};
-use generic_array::GenericArray;
 
+/// Triple DES (3DES) block cipher.
 #[derive(Copy, Clone)]
 pub struct TdesEde3 {
     d1: Des,
@@ -12,6 +15,7 @@ pub struct TdesEde3 {
     d3: Des,
 }
 
+/// Triple DES (3DES) block cipher.
 #[derive(Copy, Clone)]
 pub struct TdesEee3 {
     d1: Des,
@@ -19,22 +23,22 @@ pub struct TdesEee3 {
     d3: Des,
 }
 
+/// Triple DES (3DES) block cipher.
 #[derive(Copy, Clone)]
 pub struct TdesEde2 {
     d1: Des,
     d2: Des,
 }
 
+/// Triple DES (3DES) block cipher.
 #[derive(Copy, Clone)]
 pub struct TdesEee2 {
     d1: Des,
     d2: Des,
 }
 
-impl BlockCipher for TdesEde3 {
+impl NewBlockCipher for TdesEde3 {
     type KeySize = U24;
-    type BlockSize = U8;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U24>) -> Self {
         let d1 = Des {
@@ -48,6 +52,11 @@ impl BlockCipher for TdesEde3 {
         };
         Self { d1, d2, d3 }
     }
+}
+
+impl BlockCipher for TdesEde3 {
+    type BlockSize = U8;
+    type ParBlocks = U1;
 
     fn encrypt_block(&self, block: &mut GenericArray<u8, U8>) {
         let mut data = BE::read_u64(block);
@@ -67,26 +76,29 @@ impl BlockCipher for TdesEde3 {
         data = self.d1.decrypt(data);
 
         BE::write_u64(block, data);
+    }
+}
+
+impl NewBlockCipher for TdesEee3 {
+    type KeySize = U24;
+
+    fn new(key: &GenericArray<u8, U24>) -> Self {
+        let d1 = Des {
+            keys: gen_keys(BE::read_u64(&key[0..8])),
+        };
+        let d2 = Des {
+            keys: gen_keys(BE::read_u64(&key[8..16])),
+        };
+        let d3 = Des {
+            keys: gen_keys(BE::read_u64(&key[16..24])),
+        };
+        Self { d1, d2, d3 }
     }
 }
 
 impl BlockCipher for TdesEee3 {
-    type KeySize = U24;
     type BlockSize = U8;
     type ParBlocks = U1;
-
-    fn new(key: &GenericArray<u8, U24>) -> Self {
-        let d1 = Des {
-            keys: gen_keys(BE::read_u64(&key[0..8])),
-        };
-        let d2 = Des {
-            keys: gen_keys(BE::read_u64(&key[8..16])),
-        };
-        let d3 = Des {
-            keys: gen_keys(BE::read_u64(&key[16..24])),
-        };
-        Self { d1, d2, d3 }
-    }
 
     fn encrypt_block(&self, block: &mut GenericArray<u8, U8>) {
         let mut data = BE::read_u64(block);
@@ -109,10 +121,8 @@ impl BlockCipher for TdesEee3 {
     }
 }
 
-impl BlockCipher for TdesEde2 {
+impl NewBlockCipher for TdesEde2 {
     type KeySize = U16;
-    type BlockSize = U8;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U16>) -> Self {
         let d1 = Des {
@@ -123,6 +133,11 @@ impl BlockCipher for TdesEde2 {
         };
         Self { d1, d2 }
     }
+}
+
+impl BlockCipher for TdesEde2 {
+    type BlockSize = U8;
+    type ParBlocks = U1;
 
     fn encrypt_block(&self, block: &mut GenericArray<u8, U8>) {
         let mut data = BE::read_u64(block);
@@ -145,10 +160,8 @@ impl BlockCipher for TdesEde2 {
     }
 }
 
-impl BlockCipher for TdesEee2 {
+impl NewBlockCipher for TdesEee2 {
     type KeySize = U16;
-    type BlockSize = U8;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U16>) -> Self {
         let d1 = Des {
@@ -159,6 +172,11 @@ impl BlockCipher for TdesEee2 {
         };
         Self { d1, d2 }
     }
+}
+
+impl BlockCipher for TdesEee2 {
+    type BlockSize = U8;
+    type ParBlocks = U1;
 
     fn encrypt_block(&self, block: &mut GenericArray<u8, U8>) {
         let mut data = BE::read_u64(block);

--- a/des/tests/lib.rs
+++ b/des/tests/lib.rs
@@ -2,8 +2,8 @@
 //! https://www.cosic.esat.kuleuven.be/nessie/testvectors/
 #![no_std]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate des;
+extern crate block_cipher;
+use des;
 
 new_test!(des_test, "des", des::Des);
 new_test!(tdes_ede3_test, "tdes", des::TdesEde3);


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).