### PR TITLE
idea: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 name = "idea"
 version = "0.0.1"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "opaque-debug",
 ]
 

--- a/des/tests/lib.rs
+++ b/des/tests/lib.rs
@@ -1,8 +1,9 @@
 //! Test vectors are from NESSIE:
 //! https://www.cosic.esat.kuleuven.be/nessie/testvectors/
+
 #![no_std]
-#[macro_use]
-extern crate block_cipher;
+
+use block_cipher::new_test;
 use des;
 
 new_test!(des_test, "des", des::Des);

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -5,14 +5,18 @@ description = "IDEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 AND MIT"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/idea"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "idea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
+
+[dev-dependencies]
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/idea/benches/lib.rs
+++ b/idea/benches/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate block_cipher_trait;
-extern crate idea;
+
+use block_cipher::bench;
 
 bench!(idea::Idea, 16);

--- a/idea/src/lib.rs
+++ b/idea/src/lib.rs
@@ -3,18 +3,25 @@
 //! [1]: https://en.wikipedia.org/wiki/International_Data_Encryption_Algorithm
 
 #![no_std]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
 
-pub extern crate block_cipher_trait;
+pub use block_cipher;
+
 #[macro_use]
 extern crate opaque_debug;
 
-use block_cipher_trait::generic_array::typenum::{U1, U16, U8};
-use block_cipher_trait::generic_array::GenericArray;
-pub use block_cipher_trait::BlockCipher;
+use block_cipher::generic_array::typenum::{U1, U16, U8};
+use block_cipher::generic_array::GenericArray;
+pub use block_cipher::{BlockCipher, NewBlockCipher};
 
 mod consts;
-use consts::{FUYI, LENGTH_SUB_KEYS, MAXIM, ONE, ROUNDS};
+use crate::consts::{FUYI, LENGTH_SUB_KEYS, MAXIM, ONE, ROUNDS};
 
+/// The International Data Encryption Algorithm (IDEA) block cipher.
 #[derive(Copy, Clone)]
 pub struct Idea {
     encryption_sub_keys: [u16; LENGTH_SUB_KEYS],
@@ -170,10 +177,8 @@ impl Idea {
     }
 }
 
-impl BlockCipher for Idea {
+impl NewBlockCipher for Idea {
     type KeySize = U16;
-    type BlockSize = U8;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U16>) -> Self {
         let mut cipher = Self {
@@ -184,6 +189,11 @@ impl BlockCipher for Idea {
         cipher.invert_sub_keys();
         cipher
     }
+}
+
+impl BlockCipher for Idea {
+    type BlockSize = U8;
+    type ParBlocks = U1;
 
     fn encrypt_block(&self, block: &mut GenericArray<u8, U8>) {
         self.crypt(block, &self.encryption_sub_keys);

--- a/idea/tests/lib.rs
+++ b/idea/tests/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
-extern crate block_cipher_trait;
-extern crate idea;
 
-use block_cipher_trait::generic_array::GenericArray;
-use idea::{BlockCipher, Idea};
+use block_cipher::generic_array::GenericArray;
+use idea::{BlockCipher, Idea, NewBlockCipher};
 
 mod data;
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).