### PR TITLE
kuznyechik: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 name = "kuznyechik"
 version = "0.3.0"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "opaque-debug",
 ]
 

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -5,14 +5,15 @@ description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/kuznyechik"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "kuznyechik", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "0.7.0-pre", features = ["dev"] }

--- a/kuznyechik/benches/lib.rs
+++ b/kuznyechik/benches/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate block_cipher_trait;
-extern crate kuznyechik;
+
+use block_cipher::bench;
 
 bench!(kuznyechik::Kuznyechik, 32);

--- a/kuznyechik/src/lib.rs
+++ b/kuznyechik/src/lib.rs
@@ -1,16 +1,26 @@
+//! Pure Rust implementation of the Kuznyechik (GOST R 34.12-2015) block cipher
+
 #![no_std]
-pub extern crate block_cipher_trait;
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
 #[macro_use]
 extern crate opaque_debug;
 
-use block_cipher_trait::generic_array::typenum::{U1, U16, U32};
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+pub use block_cipher;
+
+use block_cipher::generic_array::typenum::{U1, U16, U32};
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 
 mod consts;
 
 type Block = GenericArray<u8, U16>;
 
+/// Kuznyechik (GOST R 34.12-2015) block cipher
 #[derive(Clone, Copy)]
 pub struct Kuznyechik {
     keys: [[u8; 16]; 10],
@@ -121,10 +131,8 @@ impl Kuznyechik {
     }
 }
 
-impl BlockCipher for Kuznyechik {
+impl NewBlockCipher for Kuznyechik {
     type KeySize = U32;
-    type BlockSize = U16;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U32>) -> Self {
         let mut cipher = Self {
@@ -133,15 +141,22 @@ impl BlockCipher for Kuznyechik {
         cipher.expand_key(key);
         cipher
     }
+}
+
+impl BlockCipher for Kuznyechik {
+    type BlockSize = U16;
+    type ParBlocks = U1;
 
     #[inline]
     fn encrypt_block(&self, block: &mut Block) {
+        #[allow(unsafe_code)]
         let block: &mut [u8; 16] = unsafe { core::mem::transmute(block) };
         self.encrypt(block);
     }
 
     #[inline]
     fn decrypt_block(&self, block: &mut Block) {
+        #[allow(unsafe_code)]
         let block: &mut [u8; 16] = unsafe { core::mem::transmute(block) };
         self.decrypt(block);
     }

--- a/kuznyechik/tests/lib.rs
+++ b/kuznyechik/tests/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
-extern crate block_cipher_trait;
-extern crate kuznyechik;
 
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 
 #[test]
 fn kuznyechik() {


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).