### PR TITLE
magma: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 name = "magma"
 version = "0.3.0"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -5,6 +5,7 @@ description = "Magma (GOST 28147-89 and GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/magma"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "magma", "gost", "block-cipher"]
@@ -12,11 +13,11 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [badges]
 travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/magma/benches/lib.rs
+++ b/magma/benches/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(test)]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate magma;
+extern crate block_cipher;
+use magma;
 
 bench!(magma::Magma, 32);

--- a/magma/src/construct.rs
+++ b/magma/src/construct.rs
@@ -1,14 +1,12 @@
-macro_rules! constuct_cipher {
+macro_rules! construct_cipher {
     ($name:ident, $sbox:expr) => {
         #[derive(Clone, Copy)]
         pub struct $name {
             c: Gost89,
         }
 
-        impl BlockCipher for $name {
+        impl NewBlockCipher for $name {
             type KeySize = U32;
-            type BlockSize = U8;
-            type ParBlocks = U1;
 
             fn new(key: &GenericArray<u8, U32>) -> Self {
                 let mut c = Gost89 {
@@ -18,6 +16,11 @@ macro_rules! constuct_cipher {
                 LE::read_u32_into(key, &mut c.key);
                 Self { c }
             }
+        }
+
+        impl BlockCipher for $name {
+            type BlockSize = U8;
+            type ParBlocks = U1;
 
             #[inline]
             fn encrypt_block(&self, block: &mut Block) {

--- a/magma/src/gen_table.rs
+++ b/magma/src/gen_table.rs
@@ -1,5 +1,5 @@
-use sboxes;
-use sboxes_exp;
+use crate::sboxes;
+use crate::sboxes_exp;
 
 fn gen_exp_sbox(sbox: sboxes::SBox) -> sboxes_exp::SBoxExp {
     let mut out = [[0u8; 256]; 4];

--- a/magma/src/lib.rs
+++ b/magma/src/lib.rs
@@ -1,7 +1,12 @@
+//! Pure Rust implementation of Magma (GOST 28147-89 and GOST R 34.12-2015) block cipher
+
 #![no_std]
-#![forbid(unsafe_code)]
-pub extern crate block_cipher_trait;
-extern crate byteorder;
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+
 #[macro_use]
 extern crate opaque_debug;
 
@@ -9,12 +14,14 @@ mod sboxes_exp;
 #[macro_use]
 mod construct;
 
-use block_cipher_trait::generic_array::typenum::{U1, U32, U8};
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+pub use block_cipher;
+
+use block_cipher::generic_array::typenum::{U1, U32, U8};
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use byteorder::{ByteOrder, LE};
 
-use sboxes_exp::*;
+use crate::sboxes_exp::*;
 
 type Block = GenericArray<u8, U8>;
 
@@ -82,12 +89,12 @@ impl Gost89 {
     }
 }
 
-constuct_cipher!(Magma, S_TC26);
-constuct_cipher!(Gost89Test, S_TEST);
-constuct_cipher!(Gost89CryptoProA, S_CRYPTOPRO_A);
-constuct_cipher!(Gost89CryptoProB, S_CRYPTOPRO_B);
-constuct_cipher!(Gost89CryptoProC, S_CRYPTOPRO_C);
-constuct_cipher!(Gost89CryptoProD, S_CRYPTOPRO_D);
+construct_cipher!(Magma, S_TC26);
+construct_cipher!(Gost89Test, S_TEST);
+construct_cipher!(Gost89CryptoProA, S_CRYPTOPRO_A);
+construct_cipher!(Gost89CryptoProB, S_CRYPTOPRO_B);
+construct_cipher!(Gost89CryptoProC, S_CRYPTOPRO_C);
+construct_cipher!(Gost89CryptoProD, S_CRYPTOPRO_D);
 
 #[cfg(test)]
 mod gen_table;

--- a/magma/tests/lib.rs
+++ b/magma/tests/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
-extern crate block_cipher_trait;
-extern crate magma;
 
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+use magma;
+
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 
 #[test]
 fn magma_test() {


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).