### PR TITLE
rc2: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ checksum = "38c47dcb1594802de8c02f3b899e2018c78291168a22c281be21ea0fb4796842"
 name = "rc2"
 version = "0.3.0"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "opaque-debug",
 ]
 

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -5,17 +5,18 @@ description = "RC2 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/rc2"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "rc2", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "0.7.0-pre", features = ["dev"] }
 
 [badges]
 travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/rc2/benches/lib.rs
+++ b/rc2/benches/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(test)]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate rc2;
+extern crate block_cipher;
+use rc2;
 
 bench!(rc2::Rc2, 16);

--- a/rc2/src/lib.rs
+++ b/rc2/src/lib.rs
@@ -1,19 +1,26 @@
 //! An implementation of the [RC2][1] block cipher.
 //!
 //! [1]: https://en.wikipedia.org/wiki/RC2
+
 #![no_std]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
 #![forbid(unsafe_code)]
-pub extern crate block_cipher_trait;
+#![warn(rust_2018_idioms)]
+
 #[macro_use]
 extern crate opaque_debug;
 
-use block_cipher_trait::generic_array::typenum::{U1, U32, U8};
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
-use block_cipher_trait::InvalidKeyLength;
+pub use block_cipher;
+
+use block_cipher::generic_array::typenum::{U1, U32, U8};
+use block_cipher::generic_array::GenericArray;
+use block_cipher::InvalidKeyLength;
+use block_cipher::{BlockCipher, NewBlockCipher};
 
 mod consts;
-use consts::PI_TABLE;
+use crate::consts::PI_TABLE;
 
 /// A structure that represents the block cipher initialized with a key
 pub struct Rc2 {
@@ -191,10 +198,8 @@ impl Rc2 {
     }
 }
 
-impl BlockCipher for Rc2 {
+impl NewBlockCipher for Rc2 {
     type KeySize = U32;
-    type BlockSize = U8;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U32>) -> Self {
         Self::new_varkey(key).unwrap()
@@ -207,6 +212,11 @@ impl BlockCipher for Rc2 {
             Ok(Self::new_with_eff_key_len(key, key.len() * 8))
         }
     }
+}
+
+impl BlockCipher for Rc2 {
+    type BlockSize = U8;
+    type ParBlocks = U1;
 
     fn encrypt_block(&self, block: &mut GenericArray<u8, U8>) {
         self.encrypt(block);

--- a/rc2/tests/lib.rs
+++ b/rc2/tests/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
-extern crate block_cipher_trait;
-extern crate rc2;
 
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 
 struct Test {
     key: &'static [u8],


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).