### PR TITLE
serpent: `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
 name = "serpent"
 version = "0.0.1"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -13,11 +13,11 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/serpent/tests/lib.rs
+++ b/serpent/tests/lib.rs
@@ -1,9 +1,9 @@
 //! Test vectors are from Nessie
 //! http://www.cs.technion.ac.il/~biham/Reports/Serpent/Serpent-128-128.verified.test-vectors
 #![no_std]
-extern crate serpent;
+use serpent;
 #[macro_use]
-extern crate block_cipher_trait;
+extern crate block_cipher;
 
 new_test!(serpent_test_128, "serpent_key_128bits", serpent::Serpent);
 new_test!(serpent_test_192, "serpent_key_192bits", serpent::Serpent);


### PR DESCRIPTION
Upgrades to the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).