### PR TITLE
Cargo.toml(s): remove Travis CI badges

### DIFF
--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -21,6 +21,3 @@ block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [features]
 bcrypt = []
-
-[badges]
-travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -21,6 +21,3 @@ block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [features]
 default = []
-
-[badges]
-travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -18,6 +18,3 @@ opaque-debug = "0.2"
 
 [dev-dependencies]
 block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
-
-[badges]
-travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -20,4 +20,3 @@ block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -18,6 +18,3 @@ opaque-debug = "0.2"
 
 [dev-dependencies]
 block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
-
-[badges]
-travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -17,6 +17,3 @@ opaque-debug = "0.2"
 
 [dev-dependencies]
 block-cipher = { version = "0.7.0-pre", features = ["dev"] }
-
-[badges]
-travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -21,4 +21,3 @@ block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "RustCrypto/block-ciphers" }

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -17,6 +17,3 @@ opaque-debug = "0.2"
 
 [dev-dependencies]
 block-cipher-trait = { version = "0.6", features = ["dev"] }
-
-[badges]
-travis-ci = { repository = "RustCrypto/block-ciphers" }


### PR DESCRIPTION
We've migrated to GitHub Actions.

Also it seems the badges feature of crates.io has been removed entirely(!):

https://github.com/rust-lang/crates.io/issues/2436