### PR TITLE
threefish: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -6,10 +6,13 @@ license = "MIT/Apache-2.0"
 description = "Threefish block cipher"
 documentation = "https://docs.rs/threefish"
 readme = "README.md"
+edition = "2018"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "threefish", "gost", "block-cipher"]
 
 [dependencies]
-generic-array = "0.12"
 byte-tools = "0.1"
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
+
+[dev-dependencies]
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }

--- a/threefish/benches/lib.rs
+++ b/threefish/benches/lib.rs
@@ -2,54 +2,46 @@
 #![feature(test)]
 //#[macro_use]
 //extern crate crypto_tests;
-extern crate threefish;
+use threefish;
 
-extern crate block_cipher_trait;
-extern crate generic_array;
 extern crate test;
 
-use block_cipher_trait::BlockCipher;
+use block_cipher::BlockCipher;
 use generic_array::GenericArray;
 use test::Bencher;
 
 #[bench]
 pub fn encrypt_1_256(bh: &mut Bencher) {
     let key = Default::default();
-    let tweak = Default::default();
-    let state = threefish::Threefish256::new(&key, &tweak);
+    let state = threefish::Threefish256::new(&key);
     let input = &[1u8; 32];
-    let mut output = GenericArray::default();
 
     bh.iter(|| {
-        state.encrypt_block(GenericArray::from_slice(input), &mut output);
+        state.encrypt_block(&mut GenericArray::clone_from_slice(input));
     });
     bh.bytes = 32u64;
 }
 
 #[bench]
 pub fn encrypt_2_512(bh: &mut Bencher) {
-    let key = [0u8; 64];
-    let tweak = Default::default();
-    let state = threefish::Threefish512::new(&key, &tweak);
+    let key = Default::default();
+    let state = threefish::Threefish512::new(&key);
     let input = &[1u8; 64];
-    let mut output = GenericArray::default();
 
     bh.iter(|| {
-        state.encrypt_block(GenericArray::from_slice(input), &mut output);
+        state.encrypt_block(&mut GenericArray::clone_from_slice(input));
     });
     bh.bytes = 64u64;
 }
 
 #[bench]
 pub fn encrypt_3_1024(bh: &mut Bencher) {
-    let key = [0u8; 128];
-    let tweak = Default::default();
-    let state = threefish::Threefish1024::new(&key, &tweak);
+    let key = Default::default();
+    let state = threefish::Threefish1024::new(&key);
     let input = &[1u8; 128];
-    let mut output = GenericArray::default();
 
     bh.iter(|| {
-        state.encrypt_block(GenericArray::from_slice(input), &mut output);
+        state.encrypt_block(&mut GenericArray::clone_from_slice(input));
     });
     bh.bytes = 128u64;
 }


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).