### PR TITLE
twofish: 2018 edition and `block-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,17 +42,7 @@ version = "0.7.0-pre"
 source = "git+https://github.com/RustCrypto/traits.git#9cfac08fc7c151122ddebd580e0754c240d23db2"
 dependencies = [
  "blobby",
- "generic-array 0.14.1",
-]
-
-[[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
-dependencies = [
- "blobby",
- "generic-array 0.12.3",
+ "generic-array",
 ]
 
 [[package]]
@@ -117,15 +107,6 @@ dependencies = [
  "block-cipher",
  "byteorder",
  "opaque-debug",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -234,23 +215,22 @@ version = "0.4.0-pre"
 source = "git+https://github.com/RustCrypto/traits.git#9cfac08fc7c151122ddebd580e0754c240d23db2"
 dependencies = [
  "blobby",
- "generic-array 0.14.1",
+ "generic-array",
 ]
 
 [[package]]
 name = "threefish"
 version = "0.0.1"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byte-tools 0.1.3",
- "generic-array 0.12.3",
 ]
 
 [[package]]
 name = "twofish"
 version = "0.2.0"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -5,6 +5,7 @@ description = "Twofish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/twofish"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "twofish", "block-cipher"]
@@ -12,8 +13,8 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-block-cipher-trait = "0.6"
+block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }

--- a/twofish/benches/lib.rs
+++ b/twofish/benches/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(test)]
 #[macro_use]
-extern crate block_cipher_trait;
-extern crate twofish;
+extern crate block_cipher;
+use twofish;
 
 bench!(twofish::Twofish, 16);

--- a/twofish/src/lib.rs
+++ b/twofish/src/lib.rs
@@ -1,21 +1,29 @@
+//! Twofish block cipher
+
 #![no_std]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png"
+)]
 #![forbid(unsafe_code)]
-pub extern crate block_cipher_trait;
-extern crate byteorder;
+#![warn(missing_docs, rust_2018_idioms)]
+
 #[macro_use]
 extern crate opaque_debug;
 
-use block_cipher_trait::generic_array::typenum::{U1, U16, U32};
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
-use block_cipher_trait::InvalidKeyLength;
+pub use block_cipher;
+
+use block_cipher::generic_array::typenum::{U1, U16, U32};
+use block_cipher::generic_array::GenericArray;
+use block_cipher::InvalidKeyLength;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use byteorder::{ByteOrder, LE};
 
 mod consts;
-use consts::{MDS_POLY, QBOX, QORD, RS, RS_POLY};
+use crate::consts::{MDS_POLY, QBOX, QORD, RS, RS_POLY};
 
 type Block = GenericArray<u8, U16>;
 
+/// Twofish block cipher
 pub struct Twofish {
     s: [u8; 16],  // S-box key
     k: [u32; 40], // Subkeys
@@ -151,10 +159,8 @@ impl Twofish {
     }
 }
 
-impl BlockCipher for Twofish {
+impl NewBlockCipher for Twofish {
     type KeySize = U32;
-    type BlockSize = U16;
-    type ParBlocks = U1;
 
     fn new(key: &GenericArray<u8, U32>) -> Self {
         Self::new_varkey(key).unwrap()
@@ -173,6 +179,11 @@ impl BlockCipher for Twofish {
         twofish.key_schedule(key);
         Ok(twofish)
     }
+}
+
+impl BlockCipher for Twofish {
+    type BlockSize = U16;
+    type ParBlocks = U1;
 
     fn encrypt_block(&self, block: &mut Block) {
         let mut p = [0u32; 4];

--- a/twofish/tests/lib.rs
+++ b/twofish/tests/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
-extern crate block_cipher_trait;
-extern crate twofish;
 
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use twofish::Twofish;
 
 #[test]


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `block-cipher` crate (formerly `block-cipher-trait`).