### PR TITLE
Bump all versions to `*-pre`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aes"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.3.3"
+version = "0.4.0-pre"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "aesni"
-version = "0.6.0"
+version = "0.7.0-pre"
 dependencies = [
  "block-cipher",
  "opaque-debug",
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "block-modes"
-version = "0.3.3"
+version = "0.4.0-pre"
 dependencies = [
- "aes-soft",
+ "aes",
  "block-cipher",
  "block-padding",
  "hex-literal",
@@ -93,7 +93,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cast5"
-version = "0.6.0"
+version = "0.7.0-pre"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "idea"
-version = "0.0.1"
+version = "0.1.0-pre"
 dependencies = [
  "block-cipher",
  "opaque-debug",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "block-cipher",
  "opaque-debug",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "magma"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -185,7 +185,7 @@ checksum = "38c47dcb1594802de8c02f3b899e2018c78291168a22c281be21ea0fb4796842"
 
 [[package]]
 name = "rc2"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "block-cipher",
  "opaque-debug",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "serpent"
-version = "0.0.1"
+version = "0.1.0-pre"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "sm4"
-version = "0.0.1"
+version = "0.1.0-pre"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "threefish"
-version = "0.0.1"
+version = "0.1.0-pre"
 dependencies = [
  "block-cipher",
  "byte-tools 0.1.3",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "twofish"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "block-cipher",
  "byteorder",

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.3.2"
+version = "0.4.0-pre"
 description = "Facade for AES (Rijndael) block ciphers implementations"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,10 +15,10 @@ categories = ["cryptography", "no-std"]
 block-cipher = "= 0.7.0-pre"
 
 [target.'cfg(not(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
-aes-soft = { version = "0.3", path = "aes-soft" }
+aes-soft = { version = "= 0.4.0-pre", path = "aes-soft" }
 
 [target.'cfg(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
-aesni = { version = "0.6", default-features = false, path = "aesni" }
+aesni = { version = "= 0.7.0-pre", default-features = false, path = "aesni" }
 
 [dev-dependencies]
 block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-soft"
-version = "0.3.3"
+version = "0.4.0-pre"
 description = "AES (Rijndael) block ciphers bit-sliced implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/aes/aesni/Cargo.toml
+++ b/aes/aesni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesni"
-version = "0.6.0"
+version = "0.7.0-pre"
 description = "AES (Rijndael) block ciphers implementation using AES-NI"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-modes"
-version = "0.3.3"
+version = "0.4.0-pre"
 description = "Block cipher modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ block-padding = "0.1"
 block-cipher = "= 0.7.0-pre"
 
 [dev-dependencies]
-aes-soft = { version = "0.3", path = "../aes/aes-soft" }
+aes = { version = "= 0.4.0-pre", path = "../aes" }
 hex-literal = "0.1"
 
 [features]

--- a/block-modes/src/lib.rs
+++ b/block-modes/src/lib.rs
@@ -8,7 +8,6 @@
 //! # Usage example
 //! ```
 //! # #[macro_use] extern crate hex_literal;
-//! # use aes_soft as aes;
 //! use block_modes::{BlockMode, Cbc};
 //! use block_modes::block_padding::Pkcs7;
 //! use aes::Aes128;
@@ -44,7 +43,6 @@
 //! `encrypt_vec` and `descrypt_vec` methods:
 //! ```
 //! # #[macro_use] extern crate hex_literal;
-//! # use aes_soft as aes;
 //! # use block_modes::{BlockMode, Cbc};
 //! # use block_modes::block_padding::Pkcs7;
 //! # use aes::Aes128;

--- a/block-modes/tests/lib.rs
+++ b/block-modes/tests/lib.rs
@@ -1,6 +1,6 @@
 //! Test vectors generated with OpenSSL
 
-use aes_soft::Aes128;
+use aes::Aes128;
 use block_modes::block_padding::ZeroPadding;
 use block_modes::BlockMode;
 use block_modes::{Cbc, Ecb};

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cast5"
-version = "0.6.0"
+version = "0.7.0-pre"
 description = "CAST5 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "des"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idea"
-version = "0.0.1"
+version = "0.1.0-pre"
 description = "IDEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 AND MIT"

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuznyechik"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magma"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = "Magma (GOST 28147-89 and GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc2"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = "RC2 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serpent"
-version = "0.0.1"
+version = "0.1.0-pre"
 description = "Serpent block cipher: candidate for the Advanced Encryption Standard (AES)"
 authors = ["Blocs <jonathan@cryptoblocs.fr>"]
 license = "Apache-2.0 AND MIT"

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm4"
-version = "0.0.1"
+version = "0.1.0-pre"
 authors = ["andelf <andelf@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 description = "SM4 block cipher algorithm"

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "threefish"
-version = "0.0.1"
+version = "0.1.0-pre"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT/Apache-2.0"
 description = "Threefish block cipher"

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twofish"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = "Twofish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
...to reflect the breaking 2018 edition and `block-cipher` updates