### PR TITLE
Fix or whitelist clippy nits

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -10,17 +10,16 @@ on:
       - README.md
 
 jobs:
-# TODO: clippy!
-#  clippy:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v1
-#    - uses: actions-rs/toolchain@v1
-#      with:
-#        profile: minimal
-#        toolchain: 1.41.0 # MSRV
-#        components: clippy
-#    - run: cargo clippy --all --all-features -- -D warnings
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.41.0 # MSRV
+        components: clippy
+    - run: cargo clippy --all --all-features -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/aes/aes-soft/src/bitslice.rs
+++ b/aes/aes-soft/src/bitslice.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::many_single_char_names)]
+#![allow(
+    clippy::many_single_char_names,
+    clippy::needless_range_loop,
+    clippy::unreadable_literal
+)]
 
 use crate::consts::U32X4_1;
 use crate::simd::u32x4;

--- a/aes/aes-soft/src/consts.rs
+++ b/aes/aes-soft/src/consts.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unreadable_literal)]
+
 use crate::simd::u32x4;
 
 pub const U32X4_0: u32x4 = u32x4(0, 0, 0, 0);

--- a/aes/aes-soft/src/expand.rs
+++ b/aes/aes-soft/src/expand.rs
@@ -1,3 +1,9 @@
+#![allow(
+    clippy::explicit_counter_loop,
+    clippy::needless_range_loop,
+    clippy::unreadable_literal
+)]
+
 use block_cipher::generic_array::{ArrayLength, GenericArray};
 
 use crate::bitslice::{

--- a/aes/aes-soft/src/impls.rs
+++ b/aes/aes-soft/src/impls.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::transmute_ptr_to_ptr)] // TODO: replace with casts
+
 use core::mem;
 
 use block_cipher::generic_array::typenum::{U11, U13, U15, U24, U32};

--- a/aes/aesni/src/aes128.rs
+++ b/aes/aesni/src/aes128.rs
@@ -4,7 +4,6 @@ use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 
 use crate::utils::{Block128, Block128x8};
-use core::mem;
 
 mod expand;
 #[cfg(test)]
@@ -61,8 +60,10 @@ impl NewBlockCipher for Aes128 {
 
     #[inline]
     fn new(key: &GenericArray<u8, U16>) -> Self {
-        let key = unsafe { mem::transmute(key) };
+        let key = unsafe { &*(key as *const _ as *const [u8; 16]) };
+
         let (encrypt_keys, decrypt_keys) = expand::expand(key);
+
         Self {
             encrypt_keys,
             decrypt_keys,
@@ -76,6 +77,8 @@ impl BlockCipher for Aes128 {
 
     #[inline]
     fn encrypt_block(&self, block: &mut Block128) {
+        // Safety: `loadu` and `storeu` support unaligned access
+        #[allow(clippy::cast_ptr_alignment)]
         unsafe {
             let b = _mm_loadu_si128(block.as_ptr() as *const __m128i);
             let b = self.encrypt(b);
@@ -86,6 +89,9 @@ impl BlockCipher for Aes128 {
     #[inline]
     fn decrypt_block(&self, block: &mut Block128) {
         let keys = self.decrypt_keys;
+
+        // Safety: `loadu` and `storeu` support unaligned access
+        #[allow(clippy::cast_ptr_alignment)]
         unsafe {
             let mut b = _mm_loadu_si128(block.as_ptr() as *const __m128i);
             b = _mm_xor_si128(b, keys[10]);

--- a/aes/aesni/src/aes128/expand.rs
+++ b/aes/aesni/src/aes128/expand.rs
@@ -26,10 +26,14 @@ macro_rules! expand_round {
 
 #[inline(always)]
 pub(super) fn expand(key: &[u8; 16]) -> ([__m128i; 11], [__m128i; 11]) {
+    // TODO: eliminate usage of `MaybeUninit` and/or verify soundness
+    #[allow(clippy::uninit_assumed_init)]
     unsafe {
         let mut enc_keys: [__m128i; 11] = MaybeUninit::uninit().assume_init();
         let mut dec_keys: [__m128i; 11] = MaybeUninit::uninit().assume_init();
 
+        // Safety: `loadu` supports unaligned loads
+        #[allow(clippy::cast_ptr_alignment)]
         let k = _mm_loadu_si128(key.as_ptr() as *const __m128i);
         _mm_store_si128(enc_keys.as_mut_ptr(), k);
         _mm_store_si128(dec_keys.as_mut_ptr(), k);

--- a/aes/aesni/src/aes192.rs
+++ b/aes/aesni/src/aes192.rs
@@ -4,7 +4,6 @@ use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 
 use crate::utils::{Block128, Block128x8};
-use core::mem;
 
 mod expand;
 #[cfg(test)]
@@ -65,7 +64,7 @@ impl NewBlockCipher for Aes192 {
 
     #[inline]
     fn new(key: &GenericArray<u8, U24>) -> Self {
-        let key = unsafe { mem::transmute(key) };
+        let key = unsafe { &*(key as *const _ as *const [u8; 24]) };
         let (encrypt_keys, decrypt_keys) = expand::expand(key);
         Self {
             encrypt_keys,
@@ -80,6 +79,8 @@ impl BlockCipher for Aes192 {
 
     #[inline]
     fn encrypt_block(&self, block: &mut Block128) {
+        // Safety: `loadu` and `storeu` support unaligned access
+        #[allow(clippy::cast_ptr_alignment)]
         unsafe {
             let b = _mm_loadu_si128(block.as_ptr() as *const __m128i);
             let b = self.encrypt(b);
@@ -90,6 +91,9 @@ impl BlockCipher for Aes192 {
     #[inline]
     fn decrypt_block(&self, block: &mut Block128) {
         let keys = self.decrypt_keys;
+
+        // Safety: `loadu` and `storeu` support unaligned access
+        #[allow(clippy::cast_ptr_alignment)]
         unsafe {
             let mut b = _mm_loadu_si128(block.as_ptr() as *const __m128i);
             b = _mm_xor_si128(b, keys[12]);

--- a/aes/aesni/src/aes256/expand.rs
+++ b/aes/aesni/src/aes256/expand.rs
@@ -63,9 +63,18 @@ macro_rules! expand_round_last {
 
 #[inline(always)]
 pub(super) fn expand(key: &[u8; 32]) -> ([__m128i; 15], [__m128i; 15]) {
+    // Safety: `loadu` and `storeu` support unaligned access
+    #[allow(clippy::cast_ptr_alignment)]
     unsafe {
-        let mut enc_keys: [__m128i; 15] = MaybeUninit::uninit().assume_init();
-        let mut dec_keys: [__m128i; 15] = MaybeUninit::uninit().assume_init();
+        // TODO: eliminate usage of `MaybeUninit` and/or verify soundness
+        #[allow(clippy::uninit_assumed_init)]
+        let (mut enc_keys, mut dec_keys): (
+            [__m128i; 15],
+            [__m128i; 15],
+        ) = (
+            MaybeUninit::uninit().assume_init(),
+            MaybeUninit::uninit().assume_init(),
+        );
 
         let kp = key.as_ptr() as *const __m128i;
         let k1 = _mm_loadu_si128(kp);

--- a/aes/aesni/src/ctr.rs
+++ b/aes/aesni/src/ctr.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unreadable_literal)]
+
 use crate::arch::*;
 use core::cmp;
 use core::mem::{self, MaybeUninit};
@@ -25,6 +27,9 @@ pub fn xor(buf: &mut [u8], key: &[u8]) {
 #[inline(always)]
 fn xor_block8(buf: &mut [u8], ctr: [__m128i; 8]) {
     debug_assert_eq!(buf.len(), PAR_BLOCKS_SIZE);
+
+    // Safety: `loadu` and `storeu` support unaligned access
+    #[allow(clippy::cast_ptr_alignment)]
     unsafe {
         // compiler should unroll this loop
         for i in 0..8 {
@@ -51,7 +56,11 @@ fn inc_be(v: __m128i) -> __m128i {
 
 #[inline(always)]
 fn load(val: &GenericArray<u8, U16>) -> __m128i {
-    unsafe { _mm_loadu_si128(val.as_ptr() as *const __m128i) }
+    // Safety: `loadu` supports unaligned loads
+    #[allow(clippy::cast_ptr_alignment)]
+    unsafe {
+        _mm_loadu_si128(val.as_ptr() as *const __m128i)
+    }
 }
 
 macro_rules! impl_ctr {

--- a/blowfish/src/consts.rs
+++ b/blowfish/src/consts.rs
@@ -1,4 +1,5 @@
-#![cfg_attr(feature="cargo-clippy", allow(unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
+
 pub const P: [u32; 18] = [
     0x243f6a88, 0x85a308d3, 0x13198a2e, 0x03707344, 0xa4093822, 0x299f31d0,
     0x082efa98, 0xec4e6c89, 0x452821e6, 0x38d01377, 0xbe5466cf, 0x34e90c6c,

--- a/blowfish/src/lib.rs
+++ b/blowfish/src/lib.rs
@@ -76,6 +76,7 @@ impl<T: ByteOrder> Blowfish<T> {
         }
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn round_function(&self, x: u32) -> u32 {
         let a = self.s[0][(x >> 24) as usize];
         let b = self.s[1][((x >> 16) & 0xff) as usize];
@@ -152,6 +153,7 @@ impl<T: ByteOrder> BlockCipher for Blowfish<T> {
 /// Bcrypt extension of blowfish
 #[cfg(feature = "bcrypt")]
 impl Blowfish<BE> {
+    /// Salted expand key
     pub fn salted_expand_key(&mut self, salt: &[u8], key: &[u8]) {
         let mut key_pos = 0;
         for i in 0..18 {
@@ -186,14 +188,17 @@ impl Blowfish<BE> {
         }
     }
 
+    /// Init state
     pub fn bc_init_state() -> Blowfish<BE> {
         Blowfish::init_state()
     }
 
+    /// Encrypt
     pub fn bc_encrypt(&self, l: u32, r: u32) -> (u32, u32) {
         self.encrypt(l, r)
     }
 
+    /// Expand key
     pub fn bc_expand_key(&mut self, key: &[u8]) {
         self.expand_key(key)
     }

--- a/cast5/src/consts.rs
+++ b/cast5/src/consts.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 pub const S1: [u32; 256] = [
     0x30fb40d4, 0x9fa0ff0b, 0x6beccd2f, 0x3f258c7a, 0x1e213f2f, 0x9c004dd3,

--- a/des/src/consts.rs
+++ b/des/src/consts.rs
@@ -6,7 +6,7 @@ pub const SHIFTS: [u8; 16] = [1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1];
 // rearranged so that the bottom four bits choose the column and the top two
 // bits choose the row. In other words, we can directly index the sbox array
 // with the 6 input bits to get the correct value.
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 pub const SBOXES: [[u8; 64]; 8] = [
     [
         14,  0,  4, 15, 13,  7,  1,  4,  2, 14, 15,  2, 11, 13,  8,  1,

--- a/des/src/des.rs
+++ b/des/src/des.rs
@@ -1,5 +1,7 @@
 //! Data Encryption Standard (DES) block cipher.
 
+#![allow(clippy::unreadable_literal)]
+
 use crate::generic_array::typenum::{U1, U8};
 use crate::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
@@ -164,11 +166,12 @@ fn f(input: u64, key: u64) -> u64 {
 /// Applies all eight sboxes to the input
 fn apply_sboxes(input: u64) -> u64 {
     let mut output: u64 = 0;
-    for i in 0..8 {
-        let sbox = SBOXES[i];
+
+    for (i, sbox) in SBOXES.iter().enumerate() {
         let val = (input >> (58 - (i * 6))) & 0x3F;
         output |= (sbox[val as usize] as u64) << (60 - (i * 4));
     }
+
     output
 }
 

--- a/idea/src/lib.rs
+++ b/idea/src/lib.rs
@@ -8,6 +8,7 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
+#![allow(clippy::many_single_char_names)]
 
 #[macro_use]
 extern crate opaque_debug;
@@ -138,7 +139,7 @@ impl Idea {
             let c: u32 = x * y;
             r = ((c & ONE) as i32) - ((c >> 16) as i32);
             if r < 0 {
-                r = (MAXIM as i32) + r;
+                r += MAXIM as i32;
             }
         }
 

--- a/kuznyechik/src/lib.rs
+++ b/kuznyechik/src/lib.rs
@@ -6,6 +6,7 @@
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
+#![allow(clippy::needless_range_loop, clippy::transmute_ptr_to_ptr)]
 
 #[macro_use]
 extern crate opaque_debug;

--- a/serpent/src/lib.rs
+++ b/serpent/src/lib.rs
@@ -10,6 +10,7 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
+#![allow(clippy::needless_range_loop)]
 
 #[macro_use]
 extern crate opaque_debug;
@@ -93,6 +94,7 @@ fn round_bitslice(
     }
 }
 
+#[allow(clippy::useless_let_if_seq)]
 fn round_inverse_bitslice(
     i: usize,
     b_i_next: Block128,
@@ -138,6 +140,7 @@ fn apply_s_bitslice(index: usize, word: Word) -> Word {
                 | get_bit(w3 as usize, i) << 2
                 | get_bit(w4 as usize, i) << 3,
         );
+
         for l in 0..4 {
             words[l] |= u32::from(get_bit(quad as usize, l)) << i;
         }
@@ -189,6 +192,7 @@ fn expand_key(source: &[u8], len_bits: usize, key: &mut [u8; 32]) {
 }
 
 impl Serpent {
+    #[allow(clippy::many_single_char_names)]
     fn key_schedule(key: [u8; 32]) -> Subkeys {
         let mut words = [0u32; 140];
 
@@ -210,7 +214,7 @@ impl Serpent {
         let mut k = [0u32; 132];
         for i in 0..r {
             let sbox_index = (ROUNDS + 3 - i) % ROUNDS;
-            let a = words[(4 * i + 0) as usize];
+            let a = words[(4 * i) as usize];
             let b = words[(4 * i + 1) as usize];
             let c = words[(4 * i + 2) as usize];
             let d = words[(4 * i + 3) as usize];

--- a/sm4/src/lib.rs
+++ b/sm4/src/lib.rs
@@ -8,6 +8,7 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms)]
+#![allow(clippy::unreadable_literal)]
 
 pub use block_cipher;
 
@@ -104,11 +105,12 @@ impl NewBlockCipher for Sm4 {
             [mk[0] ^ FK[0], mk[1] ^ FK[1], mk[2] ^ FK[2], mk[3] ^ FK[3]];
 
         for i in 0..8 {
-            k[0] = k[0] ^ t_prime(k[1] ^ k[2] ^ k[3] ^ CK[i * 4]);
-            k[1] = k[1] ^ t_prime(k[2] ^ k[3] ^ k[0] ^ CK[i * 4 + 1]);
-            k[2] = k[2] ^ t_prime(k[3] ^ k[0] ^ k[1] ^ CK[i * 4 + 2]);
-            k[3] = k[3] ^ t_prime(k[0] ^ k[1] ^ k[2] ^ CK[i * 4 + 3]);
-            rk[i * 4 + 0] = k[0];
+            k[0] ^= t_prime(k[1] ^ k[2] ^ k[3] ^ CK[i * 4]);
+            k[1] ^= t_prime(k[2] ^ k[3] ^ k[0] ^ CK[i * 4 + 1]);
+            k[2] ^= t_prime(k[3] ^ k[0] ^ k[1] ^ CK[i * 4 + 2]);
+            k[3] ^= t_prime(k[0] ^ k[1] ^ k[2] ^ CK[i * 4 + 3]);
+
+            rk[i * 4] = k[0];
             rk[i * 4 + 1] = k[1];
             rk[i * 4 + 2] = k[2];
             rk[i * 4 + 3] = k[3];
@@ -127,10 +129,10 @@ impl BlockCipher for Sm4 {
         BE::read_u32_into(block, &mut x);
         let rk = &self.rk;
         for i in 0..8 {
-            x[0] = x[0] ^ t(x[1] ^ x[2] ^ x[3] ^ rk[i * 4]);
-            x[1] = x[1] ^ t(x[2] ^ x[3] ^ x[0] ^ rk[i * 4 + 1]);
-            x[2] = x[2] ^ t(x[3] ^ x[0] ^ x[1] ^ rk[i * 4 + 2]);
-            x[3] = x[3] ^ t(x[0] ^ x[1] ^ x[2] ^ rk[i * 4 + 3]);
+            x[0] ^= t(x[1] ^ x[2] ^ x[3] ^ rk[i * 4]);
+            x[1] ^= t(x[2] ^ x[3] ^ x[0] ^ rk[i * 4 + 1]);
+            x[2] ^= t(x[3] ^ x[0] ^ x[1] ^ rk[i * 4 + 2]);
+            x[3] ^= t(x[0] ^ x[1] ^ x[2] ^ rk[i * 4 + 3]);
         }
         x = [x[3], x[2], x[1], x[0]];
         BE::write_u32_into(&x, block);
@@ -141,10 +143,10 @@ impl BlockCipher for Sm4 {
         BE::read_u32_into(block, &mut x);
         let rk = &self.rk;
         for i in 0..8 {
-            x[0] = x[0] ^ t(x[1] ^ x[2] ^ x[3] ^ rk[31 - i * 4]);
-            x[1] = x[1] ^ t(x[2] ^ x[3] ^ x[0] ^ rk[31 - (i * 4 + 1)]);
-            x[2] = x[2] ^ t(x[3] ^ x[0] ^ x[1] ^ rk[31 - (i * 4 + 2)]);
-            x[3] = x[3] ^ t(x[0] ^ x[1] ^ x[2] ^ rk[31 - (i * 4 + 3)]);
+            x[0] ^= t(x[1] ^ x[2] ^ x[3] ^ rk[31 - i * 4]);
+            x[1] ^= t(x[2] ^ x[3] ^ x[0] ^ rk[31 - (i * 4 + 1)]);
+            x[2] ^= t(x[3] ^ x[0] ^ x[1] ^ rk[31 - (i * 4 + 2)]);
+            x[3] ^= t(x[0] ^ x[1] ^ x[2] ^ rk[31 - (i * 4 + 3)]);
         }
         x = [x[3], x[2], x[1], x[0]];
         BE::write_u32_into(&x, block);

--- a/threefish/src/consts.rs
+++ b/threefish/src/consts.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unreadable_literal)]
+
 // Magic constant for key schedule
 pub const C240: u64 = 0x1BD11BDAA9FC1A22;
 

--- a/twofish/src/consts.rs
+++ b/twofish/src/consts.rs
@@ -5,7 +5,7 @@ pub const QORD: [[usize; 5]; 4] = [
     [1, 0, 1, 1, 0],
 ];
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 pub const QBOX: [[[u8; 16]; 4]; 2] = [
     [
         [

--- a/twofish/src/lib.rs
+++ b/twofish/src/lib.rs
@@ -6,6 +6,7 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
+#![allow(clippy::needless_range_loop, clippy::unreadable_literal)]
 
 #[macro_use]
 extern crate opaque_debug;
@@ -89,19 +90,20 @@ fn rs_mult(m: &[u8], out: &mut [u8]) {
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 fn h(x: u32, m: &[u8], k: usize, offset: usize) -> u32 {
     let mut y = [0u8; 4];
     LE::write_u32(&mut y, x);
 
     if k == 4 {
-        y[0] = sbox(1, y[0]) ^ m[4 * (6 + offset) + 0];
+        y[0] = sbox(1, y[0]) ^ m[4 * (6 + offset)];
         y[1] = sbox(0, y[1]) ^ m[4 * (6 + offset) + 1];
         y[2] = sbox(0, y[2]) ^ m[4 * (6 + offset) + 2];
         y[3] = sbox(1, y[3]) ^ m[4 * (6 + offset) + 3];
     }
 
     if k >= 3 {
-        y[0] = sbox(1, y[0]) ^ m[4 * (4 + offset) + 0];
+        y[0] = sbox(1, y[0]) ^ m[4 * (4 + offset)];
         y[1] = sbox(1, y[1]) ^ m[4 * (4 + offset) + 1];
         y[2] = sbox(0, y[2]) ^ m[4 * (4 + offset) + 2];
         y[3] = sbox(0, y[3]) ^ m[4 * (4 + offset) + 3];
@@ -109,7 +111,7 @@ fn h(x: u32, m: &[u8], k: usize, offset: usize) -> u32 {
 
     let a = 4 * (2 + offset);
     let b = 4 * offset;
-    y[0] = sbox(1, sbox(0, sbox(0, y[0]) ^ m[a + 0]) ^ m[b + 0]);
+    y[0] = sbox(1, sbox(0, sbox(0, y[0]) ^ m[a]) ^ m[b]);
     y[1] = sbox(0, sbox(0, sbox(1, y[1]) ^ m[a + 1]) ^ m[b + 1]);
     y[2] = sbox(1, sbox(1, sbox(0, y[2]) ^ m[a + 2]) ^ m[b + 2]);
     y[3] = sbox(0, sbox(1, sbox(1, y[3]) ^ m[a + 3]) ^ m[b + 3]);


### PR DESCRIPTION
This commit allows this workspace to pass `cargo clippy`, either by applying clippy's advice, or whitelisting the code with `#[clippy::*]` attributes.