### PR TITLE
Use `block_cipher::consts::*`

### DIFF
--- a/aes/aes-soft/src/impls.rs
+++ b/aes/aes-soft/src/impls.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::transmute_ptr_to_ptr)] // TODO: replace with casts
 
-use core::mem;
-
-use block_cipher::generic_array::typenum::{U11, U13, U15, U24, U32};
-use block_cipher::generic_array::typenum::{U16, U8};
-use block_cipher::generic_array::GenericArray;
 pub use block_cipher::{BlockCipher, NewBlockCipher};
+
+use block_cipher::consts::{U11, U13, U15, U16, U24, U32, U8};
+use block_cipher::generic_array::GenericArray;
+use core::mem;
 
 use crate::bitslice::{
     bit_slice_1x128_with_u32x4, bit_slice_1x16_with_u16,

--- a/aes/aesni/src/aes128.rs
+++ b/aes/aesni/src/aes128.rs
@@ -1,5 +1,5 @@
 use crate::arch::*;
-use block_cipher::generic_array::typenum::{U16, U8};
+use block_cipher::consts::{U16, U8};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 

--- a/aes/aesni/src/aes192.rs
+++ b/aes/aesni/src/aes192.rs
@@ -1,5 +1,5 @@
 use crate::arch::*;
-use block_cipher::generic_array::typenum::{U16, U24, U8};
+use block_cipher::consts::{U16, U24, U8};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 

--- a/aes/aesni/src/aes256.rs
+++ b/aes/aesni/src/aes256.rs
@@ -1,5 +1,5 @@
 use crate::arch::*;
-use block_cipher::generic_array::typenum::{U16, U32, U8};
+use block_cipher::consts::{U16, U32, U8};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 

--- a/aes/aesni/src/ctr.rs
+++ b/aes/aesni/src/ctr.rs
@@ -5,7 +5,7 @@ use core::cmp;
 use core::mem::{self, MaybeUninit};
 
 use super::{Aes128, Aes192, Aes256};
-use block_cipher::generic_array::typenum::U16;
+use block_cipher::consts::U16;
 use block_cipher::generic_array::GenericArray;
 use block_cipher::NewBlockCipher;
 use stream_cipher::{

--- a/aes/aesni/src/utils.rs
+++ b/aes/aesni/src/utils.rs
@@ -3,7 +3,7 @@ use crate::arch::__m128i;
 #[cfg(test)]
 use core::mem;
 
-use block_cipher::generic_array::typenum::{U16, U8};
+use block_cipher::consts::{U16, U8};
 use block_cipher::generic_array::GenericArray;
 
 pub type Block128 = GenericArray<u8, U16>;

--- a/blowfish/src/lib.rs
+++ b/blowfish/src/lib.rs
@@ -12,7 +12,7 @@ extern crate opaque_debug;
 
 pub use block_cipher;
 
-use block_cipher::generic_array::typenum::{U1, U56, U8};
+use block_cipher::consts::{U1, U56, U8};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::InvalidKeyLength;
 use block_cipher::{BlockCipher, NewBlockCipher};

--- a/cast5/src/cast5.rs
+++ b/cast5/src/cast5.rs
@@ -1,4 +1,4 @@
-use block_cipher::generic_array::typenum::{U1, U16, U8};
+use block_cipher::consts::{U1, U16, U8};
 use block_cipher::generic_array::GenericArray;
 
 use block_cipher::{BlockCipher, InvalidKeyLength, NewBlockCipher};

--- a/des/src/des.rs
+++ b/des/src/des.rs
@@ -2,8 +2,8 @@
 
 #![allow(clippy::unreadable_literal)]
 
-use crate::generic_array::typenum::{U1, U8};
-use crate::generic_array::GenericArray;
+use block_cipher::consts::{U1, U8};
+use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 use byteorder::{ByteOrder, BE};
 

--- a/des/src/lib.rs
+++ b/des/src/lib.rs
@@ -18,7 +18,5 @@ mod consts;
 mod des;
 mod tdes;
 
-use block_cipher::generic_array;
-
 pub use crate::des::Des;
 pub use crate::tdes::{TdesEde2, TdesEde3, TdesEee2, TdesEee3};

--- a/des/src/tdes.rs
+++ b/des/src/tdes.rs
@@ -1,10 +1,9 @@
 //! Triple DES (3DES) block cipher.
 
 use crate::des::{gen_keys, Des};
+use block_cipher::consts::{U1, U16, U24, U8};
+use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
-
-use crate::generic_array::typenum::{U1, U16, U24, U8};
-use crate::generic_array::GenericArray;
 use byteorder::{ByteOrder, BE};
 
 /// Triple DES (3DES) block cipher.

--- a/idea/src/lib.rs
+++ b/idea/src/lib.rs
@@ -15,7 +15,7 @@ extern crate opaque_debug;
 
 pub use block_cipher;
 
-use block_cipher::generic_array::typenum::{U1, U16, U8};
+use block_cipher::consts::{U1, U16, U8};
 use block_cipher::generic_array::GenericArray;
 pub use block_cipher::{BlockCipher, NewBlockCipher};
 

--- a/kuznyechik/src/lib.rs
+++ b/kuznyechik/src/lib.rs
@@ -13,7 +13,7 @@ extern crate opaque_debug;
 
 pub use block_cipher;
 
-use block_cipher::generic_array::typenum::{U1, U16, U32};
+use block_cipher::consts::{U1, U16, U32};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 

--- a/magma/src/lib.rs
+++ b/magma/src/lib.rs
@@ -16,7 +16,7 @@ mod construct;
 
 pub use block_cipher;
 
-use block_cipher::generic_array::typenum::{U1, U32, U8};
+use block_cipher::consts::{U1, U32, U8};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 use byteorder::{ByteOrder, LE};

--- a/rc2/src/lib.rs
+++ b/rc2/src/lib.rs
@@ -14,7 +14,7 @@ extern crate opaque_debug;
 
 pub use block_cipher;
 
-use block_cipher::generic_array::typenum::{U1, U32, U8};
+use block_cipher::consts::{U1, U32, U8};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::InvalidKeyLength;
 use block_cipher::{BlockCipher, NewBlockCipher};

--- a/serpent/src/lib.rs
+++ b/serpent/src/lib.rs
@@ -17,7 +17,7 @@ extern crate opaque_debug;
 
 pub use block_cipher;
 
-use block_cipher::generic_array::typenum::{U1, U16};
+use block_cipher::consts::{U1, U16};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::InvalidKeyLength;
 use block_cipher::{BlockCipher, NewBlockCipher};

--- a/sm4/src/lib.rs
+++ b/sm4/src/lib.rs
@@ -12,7 +12,7 @@
 
 pub use block_cipher;
 
-use block_cipher::generic_array::typenum::{U1, U16};
+use block_cipher::consts::{U1, U16};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 use byteorder::{ByteOrder, BE};

--- a/threefish/src/lib.rs
+++ b/threefish/src/lib.rs
@@ -10,7 +10,7 @@
 mod consts;
 
 use crate::consts::{C240, P_1024, P_256, P_512, R_1024, R_256, R_512};
-use block_cipher::generic_array::typenum::{U1, U128, U32, U64};
+use block_cipher::consts::{U1, U128, U32, U64};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 use byte_tools::{read_u64v_le, write_u64v_le};

--- a/twofish/src/lib.rs
+++ b/twofish/src/lib.rs
@@ -13,7 +13,7 @@ extern crate opaque_debug;
 
 pub use block_cipher;
 
-use block_cipher::generic_array::typenum::{U1, U16, U32};
+use block_cipher::consts::{U1, U16, U32};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::InvalidKeyLength;
 use block_cipher::{BlockCipher, NewBlockCipher};


### PR DESCRIPTION
This is a re-export of `typenum::consts` which is more convenient than `block_cipher::generic_array::typenum::*`.

Inspired by a similar pattern in the `heapless` crate.