### PR TITLE
aesni: use MaybeUninit::zeroed() to init XMM registers

### DIFF
--- a/aes/aesni/src/aes128/expand.rs
+++ b/aes/aesni/src/aes128/expand.rs
@@ -26,11 +26,9 @@ macro_rules! expand_round {
 
 #[inline(always)]
 pub(super) fn expand(key: &[u8; 16]) -> ([__m128i; 11], [__m128i; 11]) {
-    // TODO: eliminate usage of `MaybeUninit` and/or verify soundness
-    #[allow(clippy::uninit_assumed_init)]
     unsafe {
-        let mut enc_keys: [__m128i; 11] = MaybeUninit::uninit().assume_init();
-        let mut dec_keys: [__m128i; 11] = MaybeUninit::uninit().assume_init();
+        let mut enc_keys: [__m128i; 11] = MaybeUninit::zeroed().assume_init();
+        let mut dec_keys: [__m128i; 11] = MaybeUninit::zeroed().assume_init();
 
         // Safety: `loadu` supports unaligned loads
         #[allow(clippy::cast_ptr_alignment)]

--- a/aes/aesni/src/aes192/expand.rs
+++ b/aes/aesni/src/aes192/expand.rs
@@ -40,11 +40,9 @@ macro_rules! shuffle {
 
 #[inline(always)]
 pub(super) fn expand(key: &[u8; 24]) -> ([__m128i; 13], [__m128i; 13]) {
-    // TODO: eliminate usage of `MaybeUninit` and/or verify soundness
-    #[allow(clippy::uninit_assumed_init)]
     unsafe {
-        let mut enc_keys: [__m128i; 13] = MaybeUninit::uninit().assume_init();
-        let mut dec_keys: [__m128i; 13] = MaybeUninit::uninit().assume_init();
+        let mut enc_keys: [__m128i; 13] = MaybeUninit::zeroed().assume_init();
+        let mut dec_keys: [__m128i; 13] = MaybeUninit::zeroed().assume_init();
 
         macro_rules! store {
             ($i:expr, $k:expr) => {

--- a/aes/aesni/src/aes256/expand.rs
+++ b/aes/aesni/src/aes256/expand.rs
@@ -66,15 +66,8 @@ pub(super) fn expand(key: &[u8; 32]) -> ([__m128i; 15], [__m128i; 15]) {
     // Safety: `loadu` and `storeu` support unaligned access
     #[allow(clippy::cast_ptr_alignment)]
     unsafe {
-        // TODO: eliminate usage of `MaybeUninit` and/or verify soundness
-        #[allow(clippy::uninit_assumed_init)]
-        let (mut enc_keys, mut dec_keys): (
-            [__m128i; 15],
-            [__m128i; 15],
-        ) = (
-            MaybeUninit::uninit().assume_init(),
-            MaybeUninit::uninit().assume_init(),
-        );
+        let mut enc_keys: [__m128i; 15] = MaybeUninit::zeroed().assume_init();
+        let mut dec_keys: [__m128i; 15] = MaybeUninit::zeroed().assume_init();
 
         let kp = key.as_ptr() as *const __m128i;
         let k1 = _mm_loadu_si128(kp);

--- a/aes/aesni/src/ctr.rs
+++ b/aes/aesni/src/ctr.rs
@@ -94,7 +94,7 @@ macro_rules! impl_ctr {
             #[inline(always)]
             fn next_block8(&mut self) -> [__m128i; 8] {
                 let mut ctr = self.ctr;
-                let mut block8: [__m128i; 8] = unsafe { MaybeUninit::uninit().assume_init() };
+                let mut block8: [__m128i; 8] = unsafe { MaybeUninit::zeroed().assume_init() };
                 for i in 0..8 {
                     block8[i] = swap_bytes(ctr);
                     ctr = inc_be(ctr);


### PR DESCRIPTION
Resolves clippy lints about soundness, and will be optimized away by the compiler:

https://rust.godbolt.org/z/inEYXR