### PR TITLE
Cargo.toml: add `aes-soft` and `aesni` crates to workspace

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -3,10 +3,10 @@ on:
   pull_request:
     paths: Cargo.lock
   push:
-    branches: develop
+    branches: master
     paths: Cargo.lock
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   security_audit:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 members = [
     "aes",
+    "aes/aes-soft",
+    "aes/aesni",
     "blowfish",
     "block-modes",
     "cast5",


### PR DESCRIPTION
This is needed to pull them in as a git dependency