### PR TITLE
Return CFB and OFB modes

### DIFF
--- a/.github/workflows/block-modes.yml
+++ b/.github/workflows/block-modes.yml
@@ -35,7 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,4 +231,3 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,3 +231,4 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -20,4 +20,5 @@ hex-literal = "0.2"
 
 [features]
 default = ["std"]
-std = []
+alloc = []
+std = ["alloc"]

--- a/block-modes/src/cfb.rs
+++ b/block-modes/src/cfb.rs
@@ -22,9 +22,11 @@ where
     P: Padding,
 {
     fn new(cipher: C, iv: &Block<C>) -> Self {
+        let mut iv = iv.clone();
+        cipher.encrypt_block(&mut iv);
         Self {
             cipher,
-            iv: iv.clone(),
+            iv,
             _p: Default::default(),
         }
     }
@@ -40,8 +42,6 @@ where
         let pb = C::ParBlocks::to_usize();
 
         if blocks.len() >= pb {
-            self.cipher.encrypt_block(&mut self.iv);
-
             // SAFETY: we have checked that `blocks` has enough elements
             #[allow(unsafe_code)]
             let mut par_iv = read_par_block::<C>(blocks);

--- a/block-modes/src/cfb.rs
+++ b/block-modes/src/cfb.rs
@@ -40,7 +40,7 @@ where
         let pb = C::ParBlocks::to_usize();
 
         #[allow(unsafe_code)]
-        if blocks.len() >= pb + 1 {
+        if blocks.len() >= pb {
             self.cipher.encrypt_block(&mut self.iv);
 
             // SAFETY: we have checked that `blocks` has enough elements
@@ -70,15 +70,13 @@ where
                 self.cipher.encrypt_blocks(&mut par_iv);
             }
             
-            let (par_block, r) = { blocks }.split_at_mut(pb);
+            let (par_block, r) = { blocks }.split_at_mut(pb - 1);
             blocks = r;
 
-            self.iv = par_block[pb - 1].clone();
-            self.cipher.encrypt_block(&mut self.iv);
-
-            for (a, b) in par_block.iter_mut().zip(par_iv.iter()) {
+            for (a, b) in par_block.iter_mut().zip(par_iv[..pb-1].iter()) {
                 xor(a, b)
             }
+            self.iv = par_iv[pb - 1].clone();
         }
 
         for block in blocks {

--- a/block-modes/src/cfb.rs
+++ b/block-modes/src/cfb.rs
@@ -1,0 +1,107 @@
+use crate::traits::BlockMode;
+use crate::utils::{Block, ParBlocks, xor};
+use block_cipher::generic_array::typenum::Unsigned;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
+use block_padding::Padding;
+use core::marker::PhantomData;
+use core::ptr;
+
+/// [Cipher feedback][1] (CFB) block mode instance with a full block feedback.
+///
+/// [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_feedback_(CFB)
+pub struct Cfb<C: BlockCipher + BlockCipher, P: Padding> {
+    cipher: C,
+    iv: GenericArray<u8, C::BlockSize>,
+    _p: PhantomData<P>,
+}
+
+impl<C, P> BlockMode<C, P> for Cfb<C, P>
+where
+    C: BlockCipher + NewBlockCipher,
+    P: Padding,
+{
+    fn new(cipher: C, iv: &Block<C>) -> Self {
+        Self {
+            cipher,
+            iv: iv.clone(),
+            _p: Default::default(),
+        }
+    }
+
+    fn encrypt_blocks(&mut self, blocks: &mut [Block<C>]) {
+        for block in blocks {
+            xor_set1(block, self.iv.as_mut_slice());
+            self.cipher.encrypt_block(&mut self.iv);
+        }
+    }
+
+    fn decrypt_blocks(&mut self, mut blocks: &mut [Block<C>]) {
+        let pb = C::ParBlocks::to_usize();
+
+        #[allow(unsafe_code)]
+        if blocks.len() >= pb + 1 {
+            self.cipher.encrypt_block(&mut self.iv);
+
+            // SAFETY: we have checked that `blocks` has enough elements
+            let mut par_iv: ParBlocks<C> = unsafe {
+                ptr::read(blocks.as_ptr() as *const ParBlocks<C>)
+            };
+            self.cipher.encrypt_blocks(&mut par_iv);
+
+            let (b, r) = { blocks }.split_at_mut(1);
+            blocks = r;
+
+            xor(&mut b[0], &self.iv);
+
+            while blocks.len() >= 2*pb - 1 {
+                // SAFETY: we have checked that `blocks` has enough elements
+                let next_par_iv: ParBlocks<C> = unsafe {
+                    let off = pb as isize - 1;
+                    ptr::read(b.as_ptr().offset(off) as *const ParBlocks<C>)
+                };
+                let (par_block, r) = { blocks }.split_at_mut(pb);
+                blocks = r;
+
+                for (a, b) in par_block.iter_mut().zip(par_iv.iter()) {
+                    xor(a, b)
+                }
+                par_iv = next_par_iv;
+                self.cipher.encrypt_blocks(&mut par_iv);
+            }
+            
+            let (par_block, r) = { blocks }.split_at_mut(pb);
+            blocks = r;
+
+            self.iv = par_block[pb - 1].clone();
+            self.cipher.encrypt_block(&mut self.iv);
+
+            for (a, b) in par_block.iter_mut().zip(par_iv.iter()) {
+                xor(a, b)
+            }
+        }
+
+        for block in blocks {
+            xor_set2(block, self.iv.as_mut_slice());
+            self.cipher.encrypt_block(&mut self.iv);
+        }
+    }
+}
+
+#[inline(always)]
+fn xor_set1(buf1: &mut [u8], buf2: &mut [u8]) {
+    for (a, b) in buf1.iter_mut().zip(buf2) {
+        let t = *a ^ *b;
+        *a = t;
+        *b = t;
+    }
+}
+
+#[inline(always)]
+fn xor_set2(buf1: &mut [u8], buf2: &mut [u8]) {
+    for (a, b) in buf1.iter_mut().zip(buf2) {
+        let t = *a;
+        *a ^= *b;
+        *b = t;
+    }
+}

--- a/block-modes/src/cfb8.rs
+++ b/block-modes/src/cfb8.rs
@@ -1,0 +1,60 @@
+use crate::traits::BlockMode;
+use crate::utils::Block;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
+use block_padding::Padding;
+use core::marker::PhantomData;
+
+/// [Cipher feedback][1] (CFB) block mode instance with a full block feedback.
+///
+/// [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_feedback_(CFB)
+pub struct Cfb8<C: BlockCipher + NewBlockCipher, P: Padding> {
+    cipher: C,
+    iv: GenericArray<u8, C::BlockSize>,
+    _p: PhantomData<P>,
+}
+
+impl<C, P> BlockMode<C, P> for Cfb8<C, P>
+where
+    C: BlockCipher + NewBlockCipher,
+    P: Padding,
+{
+    fn new(cipher: C, iv: &Block<C>) -> Self {
+        Self {
+            cipher,
+            iv: iv.clone(),
+            _p: Default::default(),
+        }
+    }
+
+    fn encrypt_blocks(&mut self, blocks: &mut [Block<C>]) {
+        let mut iv = self.iv.clone();
+        let n = iv.len();
+        for block in blocks.iter_mut() {
+            for b in block.iter_mut() {
+                let iv_copy = iv.clone();
+                self.cipher.encrypt_block(&mut iv);
+                *b ^= iv[0];
+                iv[..n - 1].clone_from_slice(&iv_copy[1..]);
+                iv[n - 1] = *b;
+            }
+        }
+        self.iv = iv;
+    }
+
+    fn decrypt_blocks(&mut self, blocks: &mut [Block<C>]) {
+        let mut iv = self.iv.clone();
+        let n = iv.len();
+        for block in blocks.iter_mut() {
+            for b in block.iter_mut() {
+                let iv_copy = iv.clone();
+                self.cipher.encrypt_block(&mut iv);
+                let t = *b;
+                *b ^= iv[0];
+                iv[..n - 1].clone_from_slice(&iv_copy[1..]);
+                iv[n - 1] = t;
+            }
+        }
+        self.iv = iv;
+    }
+}

--- a/block-modes/src/errors.rs
+++ b/block-modes/src/errors.rs
@@ -30,8 +30,4 @@ impl fmt::Display for InvalidKeyIvLength {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for InvalidKeyIvLength {
-    fn description(&self) -> &str {
-        "invalid key or IV length during block cipher mode initialization"
-    }
-}
+impl error::Error for InvalidKeyIvLength {}

--- a/block-modes/src/lib.rs
+++ b/block-modes/src/lib.rs
@@ -85,14 +85,14 @@ mod traits;
 mod utils;
 
 mod cbc;
-mod ecb;
-mod pcbc;
 mod cfb;
 mod cfb8;
+mod ecb;
 mod ofb;
+mod pcbc;
 
 pub use block_padding;
 
 pub use crate::errors::{BlockModeError, InvalidKeyIvLength};
 pub use crate::traits::BlockMode;
-pub use crate::{cbc::Cbc, ecb::Ecb, pcbc::Pcbc, cfb::Cfb, cfb8::Cfb8, ofb::Ofb};
+pub use crate::{cbc::Cbc, cfb::Cfb, cfb8::Cfb8, ecb::Ecb, ofb::Ofb, pcbc::Pcbc};

--- a/block-modes/src/lib.rs
+++ b/block-modes/src/lib.rs
@@ -1,9 +1,10 @@
 //! This crate contains generic implementation of [block cipher modes of
 //! operation][1].
 //!
-//! Note that this crate implements only modes which require padding. For CTR,
-//! CFB and OFB modes (i.e. modes which transsform block ciphers into stream
-//! ciphers) see crates in the [RustCrypto/stream-ciphers][2] repository.
+//! Note that some block modes (such as CTR, CFB, and OFB) transform block ciphers
+//! into stream ciphers. Implementations in this crate require padding, so if you
+//! want use those modes as stream ciphers (i.e. without padding), then check out
+//! crates in the [RustCrypto/stream-ciphers][2] repository.
 //!
 //! # Usage example
 //! ```
@@ -39,7 +40,7 @@
 //! # }
 //! ```
 //!
-//! With an enabled `std` feature (which is enabled by default) you can use
+//! With an enabled `alloc` feature (which is enabled by default) you can use
 //! `encrypt_vec` and `descrypt_vec` methods:
 //! ```
 //! # use aes::Aes128;
@@ -74,6 +75,8 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -84,9 +87,12 @@ mod utils;
 mod cbc;
 mod ecb;
 mod pcbc;
+mod cfb;
+mod cfb8;
+mod ofb;
 
 pub use block_padding;
 
 pub use crate::errors::{BlockModeError, InvalidKeyIvLength};
 pub use crate::traits::BlockMode;
-pub use crate::{cbc::Cbc, ecb::Ecb, pcbc::Pcbc};
+pub use crate::{cbc::Cbc, ecb::Ecb, pcbc::Pcbc, cfb::Cfb, cfb8::Cfb8, ofb::Ofb};

--- a/block-modes/src/ofb.rs
+++ b/block-modes/src/ofb.rs
@@ -1,5 +1,5 @@
 use crate::traits::BlockMode;
-use crate::utils::{Block, xor};
+use crate::utils::{xor, Block};
 use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 use block_padding::Padding;

--- a/block-modes/src/ofb.rs
+++ b/block-modes/src/ofb.rs
@@ -1,0 +1,40 @@
+use crate::traits::BlockMode;
+use crate::utils::{Block, xor};
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
+use block_padding::Padding;
+use core::marker::PhantomData;
+
+/// [Output feedback][1] (CFB) block mode instance with a full block feedback.
+///
+/// [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_feedback_(CFB)
+pub struct Ofb<C: BlockCipher + NewBlockCipher, P: Padding> {
+    cipher: C,
+    iv: GenericArray<u8, C::BlockSize>,
+    _p: PhantomData<P>,
+}
+
+impl<C, P> BlockMode<C, P> for Ofb<C, P>
+where
+    C: BlockCipher + NewBlockCipher,
+    P: Padding,
+{
+    fn new(cipher: C, iv: &Block<C>) -> Self {
+        Self {
+            cipher,
+            iv: iv.clone(),
+            _p: Default::default(),
+        }
+    }
+
+    fn encrypt_blocks(&mut self, blocks: &mut [Block<C>]) {
+        for block in blocks.iter_mut() {
+            self.cipher.encrypt_block(&mut self.iv);
+            xor(block, &self.iv);
+        }
+    }
+
+    fn decrypt_blocks(&mut self, blocks: &mut [Block<C>]) {
+        self.encrypt_blocks(blocks)
+    }
+}

--- a/block-modes/src/traits.rs
+++ b/block-modes/src/traits.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "std")]
-pub use std::vec::Vec;
+#[cfg(feature = "alloc")]
+pub use alloc::vec::Vec;
 
 use crate::errors::{BlockModeError, InvalidKeyIvLength};
 use crate::utils::{to_blocks, Block, Key};
@@ -67,7 +67,7 @@ where
     }
 
     /// Encrypt message and store result in vector.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn encrypt_vec(mut self, plaintext: &[u8]) -> Vec<u8> {
         let bs = C::BlockSize::to_usize();
         let pos = plaintext.len();
@@ -87,7 +87,7 @@ where
     }
 
     /// Encrypt message and store result in vector.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn decrypt_vec(mut self, ciphertext: &[u8]) -> Result<Vec<u8>, BlockModeError> {
         let bs = C::BlockSize::to_usize();
         if ciphertext.len() % bs != 0 {

--- a/block-modes/tests/lib.rs
+++ b/block-modes/tests/lib.rs
@@ -43,3 +43,29 @@ fn cbc_aes128() {
     mode.decrypt(&mut ct).unwrap();
     assert_eq!(ct, &plaintext[..]);
 }
+
+/// Test that parallel code works correctly
+#[test]
+fn par_blocks() {
+    use block_modes::block_padding::Pkcs7;
+    fn run<M: BlockMode<Aes128, Pkcs7>>() {
+        let key: &[u8; 16] = b"secret key data.";
+        let iv: &[u8; 16] = b"public iv data..";
+
+        for i in 1..160 {
+            let mut buf = [128u8; 160];
+
+            let cipher = M::new_var(key, iv).unwrap();
+            let ct_len = cipher.encrypt(&mut buf, i).unwrap().len();
+            let cipher = M::new_var(key, iv).unwrap();
+            let pt = cipher.decrypt(&mut buf[..ct_len]).unwrap();
+            assert!(pt.iter().all(|&b| b == 128));
+        }
+    }
+
+    run::<block_modes::Cbc<_, _>>();
+    run::<block_modes::Cfb8<_, _>>();
+    run::<block_modes::Ecb<_, _>>();
+    run::<block_modes::Ofb<_, _>>();
+    run::<block_modes::Pcbc<_, _>>();
+}


### PR DESCRIPTION
Those modes are often used with padding, even though they can be used as stream ciphers. We could wrap `StreamCipher + FromBlockCipher`, but it will be more convoluted and a bit less efficient.

This PR also adds `alloc` feature and removes `Error::description` impl.

I am not 100% confident in the CFB parallel code, so it should be properly covered by tests.