### PR TITLE
README.md(s): fix typo

### DIFF
--- a/aes/README.md
+++ b/aes/README.md
@@ -22,7 +22,7 @@ intended for direct use in applications.
 ### ⚠️ Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 To avoid this, use an [AEAD][2] mode based on AES, such as [AES-GCM][3] or [AES-GCM-SIV][4].

--- a/blowfish/README.md
+++ b/blowfish/README.md
@@ -14,7 +14,7 @@ Pure Rust implementation of the [Blowfish block cipher][1].
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/cast5/README.md
+++ b/cast5/README.md
@@ -16,7 +16,7 @@ Pure Rust implementation of the [CAST5 block cipher][1].
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/des/README.md
+++ b/des/README.md
@@ -16,7 +16,7 @@ Pure Rust implementation of the [DES cipher][1], including triple DES (3DES).
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/idea/README.md
+++ b/idea/README.md
@@ -14,7 +14,7 @@ Experimental Pure Rust implementation of the [IDEA block cipher][1].
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/kuznyechik/README.md
+++ b/kuznyechik/README.md
@@ -14,7 +14,7 @@ Pure Rust implementation of the Kuznyechik (GOST R 34.12-2015) block cipher
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/magma/README.md
+++ b/magma/README.md
@@ -14,7 +14,7 @@ Pure Rust implementation of Magma (GOST 28147-89 and GOST R 34.12-2015) block ci
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/rc2/README.md
+++ b/rc2/README.md
@@ -14,7 +14,7 @@ Pure Rust implementation of the [RC2 block cipher][1].
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/serpent/README.md
+++ b/serpent/README.md
@@ -16,7 +16,7 @@ Experimental pure Rust implementation of the [Serpent block cipher][1].
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/sm4/README.md
+++ b/sm4/README.md
@@ -14,7 +14,7 @@ Pure Rust implementation of the [SM4 block cipher][1].
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/threefish/README.md
+++ b/threefish/README.md
@@ -14,7 +14,7 @@ Pure Rust implementation of the [Threefish block cipher][1].
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/twofish/README.md
+++ b/twofish/README.md
@@ -14,7 +14,7 @@ Pure Rust implementation of the [Twofish block cipher][1].
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been


### PR DESCRIPTION
Spelling error: "integerity" -> "integrity"