### PR TITLE
aesni: impl FromBlockCipher for AES-CTR types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 [[package]]
 name = "block-cipher"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#9cfac08fc7c151122ddebd580e0754c240d23db2"
+source = "git+https://github.com/RustCrypto/traits.git#c2266385dc366383baaf5699b727a27c62d3f446"
 dependencies = [
  "blobby",
  "generic-array",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "hex-literal-impl"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4c5c844e2fee0bf673d54c2c177f1713b3d2af2ff6e666b49cb7572e6cf42d"
+checksum = "853f769599eb31de176303197b7ba4973299c38c7a7604a6bc88c3eef05b9b46"
 dependencies = [
  "proc-macro-hack",
 ]
@@ -203,9 +203,10 @@ dependencies = [
 [[package]]
 name = "stream-cipher"
 version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#9cfac08fc7c151122ddebd580e0754c240d23db2"
+source = "git+https://github.com/RustCrypto/traits.git#c2266385dc366383baaf5699b727a27c62d3f446"
 dependencies = [
  "blobby",
+ "block-cipher",
  "generic-array",
 ]
 

--- a/aes/aesni/Cargo.toml
+++ b/aes/aesni/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 block-cipher = "= 0.7.0-pre"
 opaque-debug = "0.2"
-stream-cipher = { version = "= 0.4.0-pre", optional = true }
+stream-cipher = { version = "= 0.4.0-pre", optional = true, features = ["block-cipher"] }
 
 [dev-dependencies]
 block-cipher = { version = "0.7.0-pre", features = ["dev"] }

--- a/aes/aesni/src/ctr.rs
+++ b/aes/aesni/src/ctr.rs
@@ -4,10 +4,8 @@ use crate::arch::*;
 use core::{cmp, mem};
 
 use super::{Aes128, Aes192, Aes256};
-use block_cipher::consts::U16;
-use block_cipher::generic_array::GenericArray;
-use block_cipher::NewBlockCipher;
-use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+use block_cipher::{consts::U16, generic_array::GenericArray};
+use stream_cipher::{FromBlockCipher, LoopError, SyncStreamCipher, SyncStreamCipherSeek};
 
 const BLOCK_SIZE: usize = 16;
 const PAR_BLOCKS: usize = 8;
@@ -128,16 +126,12 @@ macro_rules! impl_ctr {
             }
         }
 
-        impl NewStreamCipher for $name {
-            type KeySize = <$cipher as NewBlockCipher>::KeySize;
-            type NonceSize = U16;
+        impl FromBlockCipher for $name {
+            type BlockCipher = $cipher;
 
-            fn new(
-                key: &GenericArray<u8, Self::KeySize>,
-                nonce: &GenericArray<u8, Self::NonceSize>,
-            ) -> Self {
+            fn from_block_cipher(cipher: $cipher, nonce: &GenericArray<u8, U16>) -> Self {
                 let nonce = swap_bytes(load(nonce));
-                let cipher = <$cipher>::new(key);
+
                 Self {
                     nonce,
                     ctr: nonce,


### PR DESCRIPTION
Impls the new `FromBlockCipher` trait introduced in:

https://github.com/RustCrypto/traits/pull/164