### PR TITLE
aes-soft v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "block-cipher",
  "byteorder",

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 block-cipher = "0.7"
 
 [target.'cfg(not(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
-aes-soft = { version = "= 0.4.0-pre", path = "aes-soft" }
+aes-soft = { version = "0.4", path = "aes-soft" }
 
 [target.'cfg(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
 aesni = { version = "= 0.7.0-pre", default-features = false, path = "aesni" }

--- a/aes/aes-soft/CHANGELOG.md
+++ b/aes/aes-soft/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-05)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#86], [#122])
+- Update to Rust 2018 edition ([#86])
+ 
+[#122]: https://github.com/RustCrypto/block-ciphers/pull/122
+[#86]: https://github.com/RustCrypto/block-ciphers/pull/86
+
 ## 0.3.3 (2018-12-23)
 
 ## 0.3.2 (2018-10-04)

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-soft"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "AES (Rijndael) block ciphers bit-sliced implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -16,4 +16,4 @@ opaque-debug = "0.2"
 byteorder = { version = "1", default-features = false }
 
 [dev-dependencies]
-block-cipher = { version = "0.7.0-pre", features = ["dev"] }
+block-cipher = { version = "0.7", features = ["dev"] }


### PR DESCRIPTION
### Changed
- Bump `block-cipher` dependency to v0.7 ([#86], [#122])
- Update to Rust 2018 edition ([#86])
 
[#122]: https://github.com/RustCrypto/block-ciphers/pull/122
[#86]: https://github.com/RustCrypto/block-ciphers/pull/86
