### PR TITLE
aes: release new crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aes"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "aesni"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "block-cipher",
  "opaque-debug",

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-05)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#86], [#122])
+- Update to Rust 2018 edition ([#86])
+
+[#121]: https://github.com/RustCrypto/block-ciphers/pull/122 
+[#86]: https://github.com/RustCrypto/block-ciphers/pull/86
+
 ## 0.3.2 (2018-11-01)
 
 ## 0.3.1 (2018-10-04)

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Facade for AES (Rijndael) block ciphers implementations"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,10 +15,10 @@ categories = ["cryptography", "no-std"]
 block-cipher = "0.7"
 
 [target.'cfg(not(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
-aes-soft = { version = "= 0.4.0-pre", path = "aes-soft" }
+aes-soft = { version = "0.4", path = "aes-soft" }
 
 [target.'cfg(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
-aesni = { version = "= 0.7.0-pre", default-features = false, path = "aesni" }
+aesni = { version = "0.7", default-features = false, path = "aesni" }
 
 [dev-dependencies]
 block-cipher = { version = "0.7", features = ["dev"] }

--- a/aes/aes-soft/CHANGELOG.md
+++ b/aes/aes-soft/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-05)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#86], [#122])
+- Update to Rust 2018 edition ([#86])
+ 
+[#122]: https://github.com/RustCrypto/block-ciphers/pull/122
+[#86]: https://github.com/RustCrypto/block-ciphers/pull/86
+
 ## 0.3.3 (2018-12-23)
 
 ## 0.3.2 (2018-10-04)

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-soft"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "AES (Rijndael) block ciphers bit-sliced implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -16,4 +16,4 @@ opaque-debug = "0.2"
 byteorder = { version = "1", default-features = false }
 
 [dev-dependencies]
-block-cipher = { version = "0.7.0-pre", features = ["dev"] }
+block-cipher = { version = "0.7", features = ["dev"] }

--- a/aes/aesni/CHANGELOG.md
+++ b/aes/aesni/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2020-06-05)
+### Added
+- Impl `FromBlockCipher` for AES-CTR types ([#121])
+
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#86], [#122])
+- Update to Rust 2018 edition ([#86])
+
+[#121]: https://github.com/RustCrypto/block-ciphers/pull/122 
+[#122]: https://github.com/RustCrypto/block-ciphers/pull/122
+[#86]: https://github.com/RustCrypto/block-ciphers/pull/86
+
 ## 0.6.0 (2018-11-01)
 
 ## 0.5.1 (2018-10-04)
@@ -41,4 +53,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.1 (2017-07-31)
 
-## 0.1.0 (2017-07-21)
+## 0.1.0 (2017-07-21)~~~~

--- a/aes/aesni/Cargo.toml
+++ b/aes/aesni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesni"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = "AES (Rijndael) block ciphers implementation using AES-NI"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -15,7 +15,7 @@ block-padding = "0.1"
 block-cipher = "0.7"
 
 [dev-dependencies]
-aes = { version = "= 0.4.0-pre", path = "../aes" }
+aes = { version = "0.4", path = "../aes" }
 hex-literal = "0.2"
 
 [features]


### PR DESCRIPTION
Releases the following versions of the `aes/` crates:

- `aes` v0.4.0
- `aes-soft` v0.4.0
- `aesni` v0.7.0