### PR TITLE
block-modes v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "block-modes"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aes",
  "block-cipher",

--- a/block-modes/CHANGELOG.md
+++ b/block-modes/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-07)
+### Changed
+- Upgrade to Rust 2018 edition ([#87])
+- Bump `block-cipher` dependency to v0.7 ([#87])
+
+[#87]: https://github.com/RustCrypto/block-ciphers/pull/87
+
 ## 0.3.3 (2019-04-28)
 
 ## 0.3.2 (2019-02-04)

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-modes"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Block cipher modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Upgrade to Rust 2018 edition ([#87])
- Bump `block-cipher` dependency to v0.7 ([#87])

[#87]: https://github.com/RustCrypto/block-ciphers/pull/87

Closes #127 