### PR TITLE
Release new crates after 2018 edition / block-cipher v0.7 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -94,7 +94,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cast5"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "idea"
-version = "0.1.0-pre"
+version = "0.1.0"
 dependencies = [
  "block-cipher",
  "opaque-debug",
@@ -177,7 +177,7 @@ checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "rc2"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "block-cipher",
  "opaque-debug",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "serpent"
-version = "0.1.0-pre"
+version = "0.1.0"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "sm4"
-version = "0.1.0-pre"
+version = "0.1.0"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "threefish"
-version = "0.1.0-pre"
+version = "0.1.0"
 dependencies = [
  "block-cipher",
  "byte-tools 0.1.3",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "twofish"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "block-cipher",
  "byteorder",

--- a/aes/aesni/CHANGELOG.md
+++ b/aes/aesni/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump `block-cipher` dependency to v0.7 ([#86], [#122])
 - Update to Rust 2018 edition ([#86])
+- Use `mem::zeroed` instead of `mem::uninitialized` on XMM registers ([#109], [#110])
 
-[#121]: https://github.com/RustCrypto/block-ciphers/pull/122 
 [#122]: https://github.com/RustCrypto/block-ciphers/pull/122
+[#121]: https://github.com/RustCrypto/block-ciphers/pull/121
+[#110]: https://github.com/RustCrypto/block-ciphers/pull/110
+[#109]: https://github.com/RustCrypto/block-ciphers/pull/109
 [#86]: https://github.com/RustCrypto/block-ciphers/pull/86
 
 ## 0.6.0 (2018-11-01)

--- a/blowfish/CHANGELOG.md
+++ b/blowfish/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-06-08)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#88])
+- Upgrade to Rust 2018 edition ([#88])
+
+[#88]: https://github.com/RustCrypto/block-ciphers/pull/88
+
 ## 0.4.0 (2018-12-23)
 
 ## 0.3.1 (2018-12-17)

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blowfish"
-version = "0.4.0"
+version = "0.5.0"
 description = "Blowfish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/cast5/CHANGELOG.md
+++ b/cast5/CHANGELOG.md
@@ -5,4 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-06-08)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#89])
+- Upgrade to Rust 2018 edition ([#89])
+
+[#89]: https://github.com/RustCrypto/block-ciphers/pull/89
+
 ## 0.6.0 (2019-03-11)
+- Initial release

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cast5"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = "CAST5 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/des/CHANGELOG.md
+++ b/des/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-08)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#90])
+- Upgrade to Rust 2018 edition ([#90])
+
+[#90]: https://github.com/RustCrypto/block-ciphers/pull/90
+
 ## 0.3.0 (2018-12-23)
 
 ## 0.2.0 (2018-11-14)

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "des"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/idea/CHANGELOG.md
+++ b/idea/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.1 (2020-05-23)
+## 0.1.0 (2020-06-08)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#91])
+- Upgrade to Rust 2018 edition ([#91])
 
+[#91]: https://github.com/RustCrypto/block-ciphers/pull/91
+
+## 0.0.1 (2020-05-23)
 - Initial release

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idea"
-version = "0.1.0-pre"
+version = "0.1.0"
 description = "IDEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 AND MIT"

--- a/kuznyechik/CHANGELOG.md
+++ b/kuznyechik/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0-pre UNRELEASED
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#92])
+- Upgrade to Rust 2018 edition ([#92])
+
+### Fixed
+- Byte order ([#118])
+
+[#118]: https://github.com/RustCrypto/block-ciphers/pull/118
+[#92]: https://github.com/RustCrypto/block-ciphers/pull/92
+
 ## 0.3.0 (2018-12-23)
 
 ## 0.2.0 (2017-11-26)

--- a/magma/CHANGELOG.md
+++ b/magma/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0-pre UNRELEASED
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#93])
+- Upgrade to Rust 2018 edition ([#93])
+
+### Fixed
+- Byte order ([#118])
+
+[#118]: https://github.com/RustCrypto/block-ciphers/pull/118
+[#93]: https://github.com/RustCrypto/block-ciphers/pull/93
+
 ## 0.3.0 (2018-12-23)
 
 ## 0.2.0 (2017-11-26)

--- a/rc2/CHANGELOG.md
+++ b/rc2/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-08)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#94])
+- Upgrade to Rust 2018 edition ([#94])
+
+[#94]: https://github.com/RustCrypto/block-ciphers/pull/94
+
 ## 0.3.0 (2018-12-23)
 
 ## 0.2.0 (2017-11-26)

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc2"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "RC2 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/serpent/CHANGELOG.md
+++ b/serpent/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.1 (2020-05-23)
+## 0.1.0 (2020-06-08)
+### Added
+- Benchmarks ([#105])
 
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#95])
+- Upgrade to Rust 2018 edition ([#95])
+
+[#105]: https://github.com/RustCrypto/block-ciphers/pull/105
+[#95]: https://github.com/RustCrypto/block-ciphers/pull/95
+
+## 0.0.1 (2020-05-23)
 - Initial release

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serpent"
-version = "0.1.0-pre"
+version = "0.1.0"
 description = "Serpent block cipher: candidate for the Advanced Encryption Standard (AES)"
 authors = ["Blocs <jonathan@cryptoblocs.fr>"]
 license = "Apache-2.0 AND MIT"

--- a/sm4/CHANGELOG.md
+++ b/sm4/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.1 (2020-05-23)
+## 0.1.0 (2020-06-08)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#97])
+- Upgrade to Rust 2018 edition ([#97])
 
+[#97]: https://github.com/RustCrypto/block-ciphers/pull/97
+
+## 0.0.1 (2020-05-23)
 - Initial release

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm4"
-version = "0.1.0-pre"
+version = "0.1.0"
 authors = ["andelf <andelf@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 description = "SM4 block cipher algorithm"

--- a/threefish/CHANGELOG.md
+++ b/threefish/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.1 (2020-05-23)
+## 0.1.0 (2020-06-08)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#99])
+- Upgrade to Rust 2018 edition ([#99])
 
+[#99]: https://github.com/RustCrypto/block-ciphers/pull/99
+
+## 0.0.1 (2020-05-23)
 - Initial release

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "threefish"
-version = "0.1.0-pre"
+version = "0.1.0"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT/Apache-2.0"
 description = "Threefish block cipher"

--- a/twofish/CHANGELOG.md
+++ b/twofish/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-06-08)
+### Changed
+- Bump `block-cipher` dependency to v0.7 ([#100])
+- Upgrade to Rust 2018 edition ([#100])
+
+[#100]: https://github.com/RustCrypto/block-ciphers/pull/100
+
 ## 0.2.0 (2018-12-23)
 
 ## 0.1.0 (2017-11-26)

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twofish"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = "Twofish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This commit cuts releases of the following crates:

- `blowfish` v0.5.0
- `cast5` v0.7.0
- `des` v0.4.0
- `idea` v0.1.0
- `rc2` v0.4.0
- `serpent` v0.1.0
- `sm4` v0.1.0
- `twofish` v0.3.0
- `threefish` v0.1.0

It also adds CHANGELOG.md details to `kuznyechik` and `magma` but does not release those yet as they had endianness issues we should double check are corrected before cutting a release.