### PR TITLE
Unroll loops for additional performance

### DIFF
--- a/.github/workflows/kuznyechik.yml
+++ b/.github/workflows/kuznyechik.yml
@@ -35,7 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --release --target ${{ matrix.target }}
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -49,7 +49,5 @@ jobs:
       with:
         profile: minimal
         toolchain: ${{ matrix.rust }}
-    - run: cargo check --all-features
-    - run: cargo test --no-default-features
     - run: cargo test
-    - run: cargo test --all-features
+    - run: cargo test --features no_unroll

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -17,3 +17,8 @@ opaque-debug = "0.2"
 
 [dev-dependencies]
 block-cipher = { version = "0.7", features = ["dev"] }
+
+[features]
+# disables loop unrolling, which reduces resulting binary size,
+# but degrades performance in return
+no_unroll = []

--- a/kuznyechik/src/lib.rs
+++ b/kuznyechik/src/lib.rs
@@ -68,18 +68,18 @@ fn l_step(msg: &mut [u8; 16], i: usize) {
 fn lsx(msg: &mut [u8; 16], key: &[u8; 16]) {
     x(msg, key);
     // s
-    unroll16!{i, { msg[i] = consts::P[msg[i] as usize]; }};
+    unroll16! {i, { msg[i] = consts::P[msg[i] as usize]; }};
     // l
-    unroll16!{i, { l_step(msg, i) }};
+    unroll16! {i, { l_step(msg, i) }};
 }
 
 #[inline(always)]
 fn lsx_inv(msg: &mut [u8; 16], key: &[u8; 16]) {
     x(msg, key);
     // l_inv
-    unroll16!{i, { l_step(msg, 15 - i) }};
+    unroll16! {i, { l_step(msg, 15 - i) }};
     // s_inv
-    unroll16!{i, { msg[15 - i] = consts::P_INV[msg[15 - i] as usize]; }};
+    unroll16! {i, { msg[15 - i] = consts::P_INV[msg[15 - i] as usize]; }};
 }
 
 fn get_c(n: usize) -> [u8; 16] {

--- a/kuznyechik/src/lib.rs
+++ b/kuznyechik/src/lib.rs
@@ -17,6 +17,8 @@ use block_cipher::generic_array::GenericArray;
 use block_cipher::{BlockCipher, NewBlockCipher};
 
 mod consts;
+#[macro_use]
+mod macros;
 
 type Block = GenericArray<u8, U16>;
 
@@ -26,6 +28,7 @@ pub struct Kuznyechik {
     keys: [[u8; 16]; 10],
 }
 
+#[inline(always)]
 fn x(a: &mut [u8; 16], b: &[u8; 16]) {
     for i in 0..16 {
         a[i] ^= b[i];
@@ -33,9 +36,11 @@ fn x(a: &mut [u8; 16], b: &[u8; 16]) {
 }
 
 fn l_step(msg: &mut [u8; 16], i: usize) {
+    #[inline(always)]
     fn get_idx(b: usize, i: usize) -> usize {
         b.wrapping_sub(i) & 0x0F
     }
+    #[inline(always)]
     fn get_m(msg: &[u8; 16], b: usize, i: usize) -> usize {
         msg[get_idx(b, i)] as usize
     }
@@ -63,25 +68,18 @@ fn l_step(msg: &mut [u8; 16], i: usize) {
 fn lsx(msg: &mut [u8; 16], key: &[u8; 16]) {
     x(msg, key);
     // s
-    for i in 0..16 {
-        msg[i] = consts::P[msg[i] as usize];
-    }
+    unroll16!{i, { msg[i] = consts::P[msg[i] as usize]; }};
     // l
-    for i in 0..16 {
-        l_step(msg, i);
-    }
+    unroll16!{i, { l_step(msg, i) }};
 }
 
+#[inline(always)]
 fn lsx_inv(msg: &mut [u8; 16], key: &[u8; 16]) {
     x(msg, key);
     // l_inv
-    for i in (0..16).rev() {
-        l_step(msg, i);
-    }
+    unroll16!{i, { l_step(msg, 15 - i) }};
     // s_inv
-    for i in 0..16 {
-        msg[i] = consts::P_INV[msg[i] as usize];
-    }
+    unroll16!{i, { msg[15 - i] = consts::P_INV[msg[15 - i] as usize]; }};
 }
 
 fn get_c(n: usize) -> [u8; 16] {
@@ -124,15 +122,15 @@ impl Kuznyechik {
     }
 
     fn encrypt(&self, msg: &mut [u8; 16]) {
-        for k in &self.keys[..9] {
-            lsx(msg, k);
+        unroll9! {
+            i, { lsx(msg, &self.keys[i]) ; }
         }
         x(msg, &self.keys[9])
     }
 
     fn decrypt(&self, msg: &mut [u8; 16]) {
-        for k in self.keys[1..].iter().rev() {
-            lsx_inv(msg, k);
+        unroll9! {
+            i, { lsx_inv(msg, &self.keys[9 - i]) ; }
         }
         x(msg, &self.keys[0])
     }

--- a/kuznyechik/src/macros.rs
+++ b/kuznyechik/src/macros.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
 #[cfg(not(feature = "no_unroll"))]
 macro_rules! unroll9 {
     ($var:ident, $body:block) => {

--- a/kuznyechik/src/macros.rs
+++ b/kuznyechik/src/macros.rs
@@ -1,0 +1,50 @@
+#[cfg(not(feature = "no_unroll"))]
+macro_rules! unroll9 {
+    ($var:ident, $body:block) => {
+        { let $var: usize = 0; $body; }
+        { let $var: usize = 1; $body; }
+        { let $var: usize = 2; $body; }
+        { let $var: usize = 3; $body; }
+        { let $var: usize = 4; $body; }
+        { let $var: usize = 5; $body; }
+        { let $var: usize = 6; $body; }
+        { let $var: usize = 7; $body; }
+        { let $var: usize = 8; $body; }
+    };
+}
+
+#[cfg(feature = "no_unroll")]
+macro_rules! unroll9 {
+    ($var:ident, $body:block) => {
+        for $var in 0..9 $body
+    }
+}
+
+#[cfg(not(feature = "no_unroll"))]
+macro_rules! unroll16 {
+    ($var:ident, $body:block) => {
+        { let $var: usize = 0; $body; }
+        { let $var: usize = 1; $body; }
+        { let $var: usize = 2; $body; }
+        { let $var: usize = 3; $body; }
+        { let $var: usize = 4; $body; }
+        { let $var: usize = 5; $body; }
+        { let $var: usize = 6; $body; }
+        { let $var: usize = 7; $body; }
+        { let $var: usize = 8; $body; }
+        { let $var: usize = 9; $body; }
+        { let $var: usize = 10; $body; }
+        { let $var: usize = 11; $body; }
+        { let $var: usize = 12; $body; }
+        { let $var: usize = 13; $body; }
+        { let $var: usize = 14; $body; }
+        { let $var: usize = 15; $body; }
+    };
+}
+
+#[cfg(feature = "no_unroll")]
+macro_rules! unroll16 {
+    ($var:ident, $body:block) => {
+        for $var in 0..16 $body
+    }
+}


### PR DESCRIPTION
On my notebook I get the following results:
```
// with loop unrolling
test decrypt ... bench:         736 ns/iter (+/- 37) = 21 MB/s
test encrypt ... bench:         526 ns/iter (+/- 62) = 30 MB/s
// without loop unrolling
test decrypt ... bench:       1,237 ns/iter (+/- 71) = 12 MB/s
test encrypt ... bench:         996 ns/iter (+/- 165) = 16 MB/s
```

Unrolling can be disabled by enabling the new `no_unroll` feature.