### PR TITLE
Simplify gost-modes a bit

### DIFF
--- a/gost-modes/src/cbc.rs
+++ b/gost-modes/src/cbc.rs
@@ -1,4 +1,5 @@
 use crate::utils::xor;
+use crate::GostPadding;
 use block_modes::block_cipher::{Block, BlockCipher, NewBlockCipher};
 use block_modes::block_padding::Padding;
 use block_modes::BlockMode;
@@ -12,12 +13,13 @@ use generic_array::{ArrayLength, GenericArray};
 ///
 /// Type parameters:
 /// - `C`: block cipher.
+/// - `P`: padding algorithm. Default: `GostPadding`.
 /// - `Z`: nonce length in block sizes. Default: 1.
 ///
 /// With default parameters this mode is fully equivalent to the `Cbc` mode defined
 /// in the `block-modes` crate.
 #[derive(Clone)]
-pub struct GostCbc<C, P, Z = U1>
+pub struct GostCbc<C, P = GostPadding, Z = U1>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: IsLessOrEqual<U255>,
@@ -28,7 +30,7 @@ where
     cipher: C,
     state: GenericArray<Block<C>, Z>,
     pos: u8,
-    _p: PhantomData<(Z, P)>,
+    _p: PhantomData<P>,
 }
 
 impl<C, P, Z> BlockMode<C, P> for GostCbc<C, P, Z>

--- a/gost-modes/src/cfb.rs
+++ b/gost-modes/src/cfb.rs
@@ -1,9 +1,9 @@
 use crate::utils::xor2;
+use crate::errors::InvalidS;
 use block_modes::block_cipher::{Block, BlockCipher, NewBlockCipher};
-use core::marker::PhantomData;
 use core::ops::Sub;
-use generic_array::typenum::type_operators::{IsGreater, IsGreaterOrEqual, IsLessOrEqual};
-use generic_array::typenum::{Diff, Unsigned, U0, U255};
+use generic_array::typenum::type_operators::{IsGreaterOrEqual, IsLessOrEqual};
+use generic_array::typenum::{Diff, Unsigned, U255};
 use generic_array::{ArrayLength, GenericArray};
 use stream_cipher::{FromBlockCipher, LoopError, SyncStreamCipher};
 
@@ -14,36 +14,46 @@ type BlockSize<C> = <C as BlockCipher>::BlockSize;
 /// Type parameters:
 /// - `C`: block cipher.
 /// - `M`: nonce length in bytes. Default: block size.
-/// - `S`: number of block bytes used for message encryption. Default: block size.
 ///
 /// With default parameters this mode is fully equivalent to the `Cfb` mode defined
 /// in the `block-modes` crate.
 #[derive(Clone)]
-pub struct GostCfb<C, M = BlockSize<C>, S = BlockSize<C>>
+pub struct GostCfb<C, M = BlockSize<C>>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: IsLessOrEqual<U255>,
     M: Unsigned + ArrayLength<u8> + IsGreaterOrEqual<C::BlockSize> + Sub<C::BlockSize>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Diff<M, C::BlockSize>: ArrayLength<u8>,
 {
     cipher: C,
     block: Block<C>,
     tail: GenericArray<u8, Diff<M, C::BlockSize>>,
     pos: u8,
-    _p: PhantomData<(M, S)>,
+    s: u8,
 }
 
-impl<C, M, S> GostCfb<C, M, S>
+impl<C, M> GostCfb<C, M>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: IsLessOrEqual<U255>,
     M: Unsigned + ArrayLength<u8> + IsGreaterOrEqual<C::BlockSize> + Sub<C::BlockSize>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Diff<M, C::BlockSize>: ArrayLength<u8>,
 {
+    /// Set number of block bytes used for message encryption.
+    ///
+    /// This method should be only used right after cipher initialization,
+    /// before any data processing.
+    pub fn set_s(&mut self, s: u8) -> Result<(), InvalidS> {
+        if s > 0 && s <= C::BlockSize::U8 {
+            self.s = s;
+            Ok(())
+        } else {
+            Err(InvalidS)
+        }
+    }
+
     fn gen_block(&mut self) {
-        let s = S::USIZE;
+        let s = self.s as usize;
         let ts = self.tail.len();
         if ts <= s {
             let d = s - ts;
@@ -64,12 +74,11 @@ where
     }
 }
 
-impl<C, M, S> FromBlockCipher for GostCfb<C, M, S>
+impl<C, M> FromBlockCipher for GostCfb<C, M>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: IsLessOrEqual<U255>,
     M: Unsigned + ArrayLength<u8> + IsGreaterOrEqual<C::BlockSize> + Sub<C::BlockSize>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Diff<M, C::BlockSize>: ArrayLength<u8>,
 {
     type BlockCipher = C;
@@ -85,21 +94,20 @@ where
             block,
             tail,
             pos: 0,
-            _p: Default::default(),
+            s: C::BlockSize::U8,
         }
     }
 }
 
-impl<C, M, S> SyncStreamCipher for GostCfb<C, M, S>
+impl<C, M> SyncStreamCipher for GostCfb<C, M>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: IsLessOrEqual<U255>,
     M: Unsigned + ArrayLength<u8> + IsGreaterOrEqual<C::BlockSize> + Sub<C::BlockSize>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Diff<M, C::BlockSize>: ArrayLength<u8>,
 {
     fn try_apply_keystream(&mut self, mut data: &mut [u8]) -> Result<(), LoopError> {
-        let s = S::USIZE;
+        let s = self.s as usize;
         let pos = self.pos as usize;
 
         if data.len() < s - pos {

--- a/gost-modes/src/cfb.rs
+++ b/gost-modes/src/cfb.rs
@@ -1,5 +1,5 @@
-use crate::utils::xor2;
 use crate::errors::InvalidS;
+use crate::utils::xor2;
 use block_modes::block_cipher::{Block, BlockCipher, NewBlockCipher};
 use core::ops::Sub;
 use generic_array::typenum::type_operators::{IsGreaterOrEqual, IsLessOrEqual};

--- a/gost-modes/src/ctr.rs
+++ b/gost-modes/src/ctr.rs
@@ -1,5 +1,5 @@
-use crate::utils::xor;
 use crate::errors::InvalidS;
+use crate::utils::xor;
 use block_modes::block_cipher::{Block, BlockCipher, NewBlockCipher};
 use core::convert::TryInto;
 use core::ops::{Div, Rem};

--- a/gost-modes/src/ctr.rs
+++ b/gost-modes/src/ctr.rs
@@ -1,25 +1,20 @@
 use crate::utils::xor;
+use crate::errors::InvalidS;
 use block_modes::block_cipher::{Block, BlockCipher, NewBlockCipher};
 use core::convert::TryInto;
-use core::marker::PhantomData;
 use core::ops::{Div, Rem};
-use generic_array::typenum::type_operators::{IsEqual, IsGreater, IsLessOrEqual};
+use generic_array::typenum::type_operators::{IsEqual, IsLessOrEqual};
 use generic_array::typenum::{Mod, Quot, Unsigned, U0, U2, U255, U8};
 use generic_array::{ArrayLength, GenericArray};
 use stream_cipher::{FromBlockCipher, LoopError, SyncStreamCipher};
 
 /// Counter (CTR) block mode instance as defined in GOST R 34.13-2015.
-///
-/// Type parameters:
-/// - `C`: block cipher.
-/// - `S`: number of block bytes used for message encryption. Default: block size.
 #[derive(Clone)]
-pub struct GostCtr<C, S = <C as BlockCipher>::BlockSize>
+pub struct GostCtr<C>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: Div<U8> + Rem<U8> + Div<U2> + IsLessOrEqual<U255>,
     Mod<C::BlockSize, U8>: IsEqual<U0>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Quot<C::BlockSize, U8>: ArrayLength<u64>,
     Quot<C::BlockSize, U2>: ArrayLength<u8>,
 {
@@ -27,18 +22,30 @@ where
     block: Block<C>,
     ctr: GenericArray<u64, Quot<C::BlockSize, U8>>,
     pos: u8,
-    _p: PhantomData<S>,
+    s: u8,
 }
 
-impl<C, S> GostCtr<C, S>
+impl<C> GostCtr<C>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: Div<U8> + Rem<U8> + Div<U2> + IsLessOrEqual<U255>,
     Mod<C::BlockSize, U8>: IsEqual<U0>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Quot<C::BlockSize, U8>: ArrayLength<u64>,
     Quot<C::BlockSize, U2>: ArrayLength<u8>,
 {
+    /// Set number of block bytes used for message encryption.
+    ///
+    /// This method should be only used right after cipher initialization,
+    /// before any data processing.
+    pub fn set_s(&mut self, s: u8) -> Result<(), InvalidS> {
+        if s > 0 && s <= C::BlockSize::U8 {
+            self.s = s;
+            Ok(())
+        } else {
+            Err(InvalidS)
+        }
+    }
+
     fn gen_block(&mut self) {
         for (c, v) in self.block.chunks_mut(8).zip(self.ctr.iter()) {
             c.copy_from_slice(&v.to_be_bytes());
@@ -59,12 +66,11 @@ where
     }
 }
 
-impl<C, S> FromBlockCipher for GostCtr<C, S>
+impl<C> FromBlockCipher for GostCtr<C>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: Div<U8> + Rem<U8> + Div<U2> + IsLessOrEqual<U255>,
     Mod<C::BlockSize, U8>: IsEqual<U0>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Quot<C::BlockSize, U8>: ArrayLength<u64>,
     Quot<C::BlockSize, U2>: ArrayLength<u8>,
 {
@@ -89,24 +95,23 @@ where
             block,
             ctr,
             pos: 0,
-            _p: Default::default(),
+            s: C::BlockSize::U8,
         };
         s.gen_block();
         s
     }
 }
 
-impl<C, S> SyncStreamCipher for GostCtr<C, S>
+impl<C> SyncStreamCipher for GostCtr<C>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: Div<U8> + Rem<U8> + Div<U2> + IsLessOrEqual<U255>,
     Mod<C::BlockSize, U8>: IsEqual<U0>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Quot<C::BlockSize, U8>: ArrayLength<u64>,
     Quot<C::BlockSize, U2>: ArrayLength<u8>,
 {
     fn try_apply_keystream(&mut self, mut data: &mut [u8]) -> Result<(), LoopError> {
-        let s = S::USIZE;
+        let s = self.s as usize;
         let pos = self.pos as usize;
 
         if data.len() < s - pos {

--- a/gost-modes/src/errors.rs
+++ b/gost-modes/src/errors.rs
@@ -1,0 +1,17 @@
+use core::fmt;
+
+/// Error indicating that an invalid value was used for number of block bytes
+/// used for message processing.
+///
+/// The alue should be between greater than 0 and less or equal to cipher block size.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct InvalidS;
+
+impl fmt::Display for InvalidS {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("InvalidS")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidS {}

--- a/gost-modes/src/lib.rs
+++ b/gost-modes/src/lib.rs
@@ -65,9 +65,9 @@ pub use stream_cipher::{NewStreamCipher, SyncStreamCipher};
 mod cbc;
 mod cfb;
 mod ctr;
+mod errors;
 mod ofb;
 mod utils;
-mod errors;
 
 /// Block padding procedure number 2 as defined in GOST R 34.13-2015.
 ///
@@ -77,5 +77,5 @@ pub type GostPadding = block_padding::Iso7816;
 pub use cbc::GostCbc;
 pub use cfb::GostCfb;
 pub use ctr::GostCtr;
-pub use ofb::GostOfb;
 pub use errors::InvalidS;
+pub use ofb::GostOfb;

--- a/gost-modes/src/lib.rs
+++ b/gost-modes/src/lib.rs
@@ -50,6 +50,9 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use block_modes;
 pub use block_modes::block_cipher::consts;
 pub use block_modes::block_padding;
@@ -64,6 +67,7 @@ mod cfb;
 mod ctr;
 mod ofb;
 mod utils;
+mod errors;
 
 /// Block padding procedure number 2 as defined in GOST R 34.13-2015.
 ///
@@ -74,3 +78,4 @@ pub use cbc::GostCbc;
 pub use cfb::GostCfb;
 pub use ctr::GostCtr;
 pub use ofb::GostOfb;
+pub use errors::InvalidS;

--- a/gost-modes/src/ofb.rs
+++ b/gost-modes/src/ofb.rs
@@ -1,6 +1,6 @@
 use crate::utils::xor;
+use crate::errors::InvalidS;
 use block_modes::block_cipher::{Block, BlockCipher, NewBlockCipher};
-use core::marker::PhantomData;
 use core::ops::Mul;
 use generic_array::typenum::type_operators::{IsGreater, IsLessOrEqual};
 use generic_array::typenum::{Prod, Unsigned, U0, U1, U255};
@@ -12,16 +12,14 @@ use stream_cipher::{FromBlockCipher, LoopError, SyncStreamCipher};
 /// Type parameters:
 /// - `C`: block cipher.
 /// - `Z`: nonce length in block sizes. Default: 1.
-/// - `S`: number of block bytes used for message encryption. Default: block size.
 ///
 /// With default parameters this mode is fully equivalent to the `Ofb` mode defined
 /// in the `block-modes` crate.
 #[derive(Clone)]
-pub struct GostOfb<C, Z = U1, S = <C as BlockCipher>::BlockSize>
+pub struct GostOfb<C, Z = U1>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: IsLessOrEqual<U255>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Z: ArrayLength<Block<C>> + Unsigned + Mul<C::BlockSize> + IsGreater<U0> + IsLessOrEqual<U255>,
     Prod<Z, C::BlockSize>: ArrayLength<u8>,
 {
@@ -29,15 +27,34 @@ where
     state: GenericArray<Block<C>, Z>,
     block_pos: u8,
     pos: u8,
-    _p: PhantomData<(S, Z)>,
+    s: u8,
 }
 
-// TODO: replace with FromBlockCipher trait impl
-impl<C, Z, S> FromBlockCipher for GostOfb<C, Z, S>
+impl<C, Z> GostOfb<C, Z>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: IsLessOrEqual<U255>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
+    Z: ArrayLength<Block<C>> + Unsigned + Mul<C::BlockSize> + IsGreater<U0> + IsLessOrEqual<U255>,
+    Prod<Z, C::BlockSize>: ArrayLength<u8>,
+{
+    /// Set number of block bytes used for message encryption.
+    ///
+    /// This method should be only used right after cipher initialization,
+    /// before any data processing.
+    pub fn set_s(&mut self, s: u8) -> Result<(), InvalidS> {
+        if s > 0 && s <= C::BlockSize::U8 {
+            self.s = s;
+            Ok(())
+        } else {
+            Err(InvalidS)
+        }
+    }
+}
+
+impl<C, Z> FromBlockCipher for GostOfb<C, Z>
+where
+    C: BlockCipher + NewBlockCipher,
+    C::BlockSize: IsLessOrEqual<U255>,
     Z: ArrayLength<Block<C>> + Unsigned + Mul<C::BlockSize> + IsGreater<U0> + IsLessOrEqual<U255>,
     Prod<Z, C::BlockSize>: ArrayLength<u8>,
 {
@@ -58,21 +75,20 @@ where
             state,
             block_pos: 0,
             pos: 0,
-            _p: Default::default(),
+            s: C::BlockSize::U8,
         }
     }
 }
 
-impl<C, Z, S> SyncStreamCipher for GostOfb<C, Z, S>
+impl<C, Z> SyncStreamCipher for GostOfb<C, Z>
 where
     C: BlockCipher + NewBlockCipher,
     C::BlockSize: IsLessOrEqual<U255>,
-    S: Unsigned + IsGreater<U0> + IsLessOrEqual<C::BlockSize>,
     Z: ArrayLength<Block<C>> + Unsigned + Mul<C::BlockSize> + IsGreater<U0> + IsLessOrEqual<U255>,
     Prod<Z, C::BlockSize>: ArrayLength<u8>,
 {
     fn try_apply_keystream(&mut self, mut data: &mut [u8]) -> Result<(), LoopError> {
-        let s = S::USIZE;
+        let s = self.s as usize;
         let pos = self.pos as usize;
         let block_pos = self.block_pos as usize;
 

--- a/gost-modes/src/ofb.rs
+++ b/gost-modes/src/ofb.rs
@@ -1,5 +1,5 @@
-use crate::utils::xor;
 use crate::errors::InvalidS;
+use crate::utils::xor;
 use block_modes::block_cipher::{Block, BlockCipher, NewBlockCipher};
 use core::ops::Mul;
 use generic_array::typenum::type_operators::{IsGreater, IsLessOrEqual};


### PR DESCRIPTION
Parameter `S` (number of block bytes used for message processing) is now a runtime parameter. It simplifies type signatures a bit.