### PR TITLE
aesni: Add target_feature annotations to allow intrinsic inlining

### DIFF
--- a/aes/aesni/src/aes256.rs
+++ b/aes/aesni/src/aes256.rs
@@ -19,8 +19,9 @@ pub struct Aes256 {
 impl Aes256 {
     #[inline(always)]
     pub(crate) fn encrypt8(&self, mut blocks: [__m128i; 8]) -> [__m128i; 8] {
-        let keys = self.encrypt_keys;
-        unsafe {
+        #[inline]
+        #[target_feature(enable = "aes")]
+        unsafe fn aesni256_encrypt8(keys: &[__m128i; 15], blocks: &mut [__m128i; 8]) {
             xor8!(blocks, keys[0]);
             aesenc8!(blocks, keys[1]);
             aesenc8!(blocks, keys[2]);
@@ -37,13 +38,15 @@ impl Aes256 {
             aesenc8!(blocks, keys[13]);
             aesenclast8!(blocks, keys[14]);
         }
+        unsafe { aesni256_encrypt8(&self.encrypt_keys, &mut blocks) };
         blocks
     }
 
     #[inline(always)]
-    pub(crate) fn encrypt(&self, mut block: __m128i) -> __m128i {
-        let keys = self.encrypt_keys;
-        unsafe {
+    pub(crate) fn encrypt(&self, block: __m128i) -> __m128i {
+        #[inline]
+        #[target_feature(enable = "aes")]
+        unsafe fn aesni256_encrypt1(keys: &[__m128i; 15], mut block: __m128i) -> __m128i {
             block = _mm_xor_si128(block, keys[0]);
             block = _mm_aesenc_si128(block, keys[1]);
             block = _mm_aesenc_si128(block, keys[2]);
@@ -60,6 +63,7 @@ impl Aes256 {
             block = _mm_aesenc_si128(block, keys[13]);
             _mm_aesenclast_si128(block, keys[14])
         }
+        unsafe { aesni256_encrypt1(&self.encrypt_keys, block) }
     }
 }
 


### PR DESCRIPTION
When built with nocheck feature, the AES-NI intrinsics are not inlined causing a severe performance drop. (https://github.com/rust-lang/rust/issues/53069)

When compiled with `--features=nocheck`, improvement is notable (all numbers MB/s as reported by `cargo bench` on an i7-10510U, rustc 1.47)

| Benchmark | Current master (+aes) | Current master (nocheck) | This PR (nocheck) |
-----------------| ---------------------| --------------------| --------------------
| aes128_encrypt | 615 | 285 | 516 |
| aes128_encrypt8 | 2782 | 551 | 2327 |
| aes192_encrypt | 533 | 242 | 444 |
| aes192_encrypt8 | 2327 | 462 | 2000 |
| aes256_encrypt | 457 | 210 | 400 |
| aes256_encrypt8 | 2000 | 393 | 1753 |

When compiled with `RUSTFLAGS="-C target-feature=+aes,+ssse3"` there was no performance change (based on `cargo bench` output)

Decryption could be updated similarly. I didn't need it, but could update that as well if desired.