### PR TITLE
Release new versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aes"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "aesni"
-version = "0.10.0-pre"
+version = "0.10.0"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -34,7 +34,7 @@ checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 
 [[package]]
 name = "block-modes"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "aes",
  "block-padding",
@@ -50,7 +50,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blowfish"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -65,7 +65,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cast5"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "gost-modes"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "block-modes",
  "cipher",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "idea"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "magma"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -173,7 +173,7 @@ checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "rc2"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "serpent"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "sm4"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -200,14 +200,14 @@ dependencies = [
 
 [[package]]
 name = "threefish"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "twofish"
-version = "0.3.0-pre"
+version = "0.5.0"
 dependencies = [
  "byteorder",
  "cipher",

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.5.1 (2020-08-25)
 ### Changed
 - Bump `aesni` dependency to v0.9 ([#158])

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "Facade for AES (Rijndael) block ciphers implementations"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,10 +15,10 @@ categories = ["cryptography", "no-std"]
 cipher = "0.2"
 
 [target.'cfg(not(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
-aes-soft = { version = "=0.6.0-pre", path = "aes-soft" }
+aes-soft = { version = "0.6", path = "aes-soft" }
 
 [target.'cfg(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
-aesni = { version = "0.10.0-pre", default-features = false, path = "aesni" }
+aesni = { version = "0.10", default-features = false, path = "aesni" }
 
 [dev-dependencies]
 cipher = { version = "0.2", features = ["dev"] }

--- a/aes/aes-soft/CHANGELOG.md
+++ b/aes/aes-soft/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+- Performance improvements ([#166])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+[#166]: https://github.com/RustCrypto/block-ciphers/pull/166
+
 ## 0.5.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-soft"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "AES (Rijndael) block ciphers bit-sliced implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/aes/aesni/CHANGELOG.md
+++ b/aes/aesni/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.9.0 (2020-08-25)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7 ([#158])

--- a/aes/aesni/Cargo.toml
+++ b/aes/aesni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesni"
-version = "0.10.0-pre"
+version = "0.10.0"
 description = "AES (Rijndael) block ciphers implementation using AES-NI"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/block-modes/CHANGELOG.md
+++ b/block-modes/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.6.1 (2020-08-14)
 ### Added
 - `Clone` trait implementations ([#145])

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-modes"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = "Block cipher modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ block-padding = "0.2"
 cipher = "0.2"
 
 [dev-dependencies]
-aes = { version = "=0.6.0-pre", path = "../aes" }
+aes = { version = "0.6", path = "../aes" }
 hex-literal = "0.2"
 
 [features]

--- a/blowfish/CHANGELOG.md
+++ b/blowfish/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.6.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blowfish"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = "Blowfish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cast5/CHANGELOG.md
+++ b/cast5/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.8.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cast5"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "CAST5 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/des/CHANGELOG.md
+++ b/des/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.5.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "des"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/gost-modes/CHANGELOG.md
+++ b/gost-modes/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.3.0 (2020-08-12)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7 ([#158])

--- a/gost-modes/Cargo.toml
+++ b/gost-modes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gost-modes"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Block cipher modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -11,13 +11,13 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "block-cipher", "ciphers"]
 
 [dependencies]
-block-modes = { version = "=0.7.0-pre", path = "../block-modes", default-features = false }
+block-modes = { version = "0.7", path = "../block-modes", default-features = false }
 cipher = { version = "0.2", default-features = false }
 generic-array = "0.14"
 
 [dev-dependencies]
-kuznyechik = { version = "0.6.0-pre", path = "../kuznyechik" }
-magma = { version = "0.6.0-pre", path = "../magma" }
+kuznyechik = { version = "0.6", path = "../kuznyechik" }
+magma = { version = "0.6", path = "../magma" }
 cipher = { version = "0.2", features = ["dev"] }
 hex-literal = "0.2"
 

--- a/idea/CHANGELOG.md
+++ b/idea/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.2.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idea"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = "IDEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 AND MIT"

--- a/kuznyechik/CHANGELOG.md
+++ b/kuznyechik/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.5.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuznyechik"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/magma/CHANGELOG.md
+++ b/magma/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.5.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magma"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "Magma (GOST 28147-89 and GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/rc2/CHANGELOG.md
+++ b/rc2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.5.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc2"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "RC2 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/serpent/CHANGELOG.md
+++ b/serpent/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.2.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serpent"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = "Serpent block cipher"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/sm4/CHANGELOG.md
+++ b/sm4/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.2.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm4"
-version = "0.3.0-pre"
+version = "0.3.0"
 authors = ["andelf <andelf@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 description = "SM4 block cipher algorithm"

--- a/threefish/CHANGELOG.md
+++ b/threefish/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.2.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "threefish"
-version = "0.3.0-pre"
+version = "0.3.0"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT OR Apache-2.0"
 description = "Threefish block cipher"

--- a/twofish/CHANGELOG.md
+++ b/twofish/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])
+
+[#167]: https://github.com/RustCrypto/block-ciphers/pull/167
+
 ## 0.4.0 (2020-08-07)
 ### Changed
 - Bump `block-cipher` dependency to v0.8 ([#138])

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twofish"
-version = "0.3.0-pre"
+version = "0.5.0"
 description = "Twofish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases new versions of all crates in this repository which incorporate the migration to the new `cipher` crate (#167)