### PR TITLE
aesni/gost-modes: rustdoc fixups

### DIFF
--- a/aes/aesni/src/lib.rs
+++ b/aes/aesni/src/lib.rs
@@ -11,8 +11,8 @@
 //! otherwise you will get a compilation error. You can do it either by using
 //! `RUSTFLAGS="-C target-feature=+aes"` or by editing your `.cargo/config`.
 //!
-//! Ciphers functionality is accessed using `BlockCipher` trait from
-//! [`block-cipher-trait`](https://docs.rs/block-cipher-trait) crate.
+//! Ciphers functionality is accessed using `BlockCipher` trait from the
+//! [`cipher`](https://docs.rs/cipher) crate.
 //!
 //! # CTR mode
 //! In addition to core block cipher functionality this crate provides optimized
@@ -22,7 +22,7 @@
 //! `default-features = false` in your `Cargo.toml`.
 //!
 //! AES-CTR functionality is accessed using traits from
-//! [`stream-cipher`](https://docs.rs/stream-cipher) crate.
+//! [`cipher`](https://docs.rs/cipher) crate.
 //!
 //! # Vulnerability
 //! Lazy FP state restory vulnerability can allow local process to leak content

--- a/gost-modes/src/lib.rs
+++ b/gost-modes/src/lib.rs
@@ -1,8 +1,7 @@
 //! This crate contains generic implementation of [block cipher modes of
 //! operation][1] defined in [GOST R 34.13-2015].
 //!
-//! Note that CTR, CFB and OFB modes are implemented in terms of traits from
-//! the [`stream-cipher`] crate.
+//! CTR, CFB and OFB modes are implemented in terms of traits from the [`cipher`] crate.
 //!
 //! MAC function defined in the GOST is implemented in the [`cmac`] crate.
 //!
@@ -43,7 +42,7 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation
 //! [GOST R 34.13-2015]: https://tc26.ru/standard/gost/GOST_R_3413-2015.pdf
-//! [`stream-cipher`]: https://docs.rs/stream-cipher/
+//! [`cipher`]: https://docs.rs/cipher/
 //! [`cmac`]: https://docs.rs/cmac/
 #![no_std]
 #![doc(


### PR DESCRIPTION
Fixes links to obsolete crates (`block-cipher-traits`, `stream-cipher`)