### PR TITLE
Perf. opt. for 8-block (un)bitslice

### DIFF
--- a/aes/aes-soft/src/bitslice.rs
+++ b/aes/aes-soft/src/bitslice.rs
@@ -459,7 +459,7 @@ pub fn bit_slice_1x128_with_u32x4(data: &[u8]) -> Bs8State<u32x4> {
     let mut t6 = read_transposed(&data[96..112]);
     let mut t7 = read_transposed(&data[112..128]);
 
-    fn delta_swap(a: &mut u32x4, b: &mut u32x4, shift: u32, mask: u32x4) {
+    fn delta_swap(a: &mut u32x4, b: &mut u32x4, shift: u32, mask: u32) {
         // Per-u32-element shifts are sufficient for actual masks used
         let t = (((*b) >> shift) ^ *a) & mask;
         *a = *a ^ t;
@@ -468,7 +468,7 @@ pub fn bit_slice_1x128_with_u32x4(data: &[u8]) -> Bs8State<u32x4> {
 
     // Bit Index Swap 7 <-> 0:
     //     __ __ b0 __ __ __ __ __ __ p0 => __ __ p0 __ __ __ __ __ __ b0
-    let m0 = u32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
+    let m0 = 0x55555555;
     delta_swap(&mut t1, &mut t0, 1, m0);
     delta_swap(&mut t3, &mut t2, 1, m0);
     delta_swap(&mut t5, &mut t4, 1, m0);
@@ -476,7 +476,7 @@ pub fn bit_slice_1x128_with_u32x4(data: &[u8]) -> Bs8State<u32x4> {
 
     // Bit Index Swap 8 <-> 1:
     //     __ b1 __ __ __ __ __ __ p1 __ => __ p1 __ __ __ __ __ __ b1 __
-    let m1 = u32x4(0x33333333, 0x33333333, 0x33333333, 0x33333333);
+    let m1 = 0x33333333;
     delta_swap(&mut t2, &mut t0, 2, m1);
     delta_swap(&mut t3, &mut t1, 2, m1);
     delta_swap(&mut t6, &mut t4, 2, m1);
@@ -484,7 +484,7 @@ pub fn bit_slice_1x128_with_u32x4(data: &[u8]) -> Bs8State<u32x4> {
 
     // Bit Index Swap 9 <-> 2:
     //     b2 __ __ __ __ __ __ p2 __ __ => p2 __ __ __ __ __ __ b2 __ __
-    let m2 = u32x4(0x0F0F0F0F, 0x0F0F0F0F, 0x0F0F0F0F, 0x0F0F0F0F);
+    let m2 = 0x0F0F0F0F;
     delta_swap(&mut t4, &mut t0, 4, m2);
     delta_swap(&mut t5, &mut t1, 4, m2);
     delta_swap(&mut t6, &mut t2, 4, m2);
@@ -520,7 +520,7 @@ pub fn un_bit_slice_1x128_with_u32x4(bs: Bs8State<u32x4>, output: &mut [u8]) {
 
     let Bs8State(mut t0, mut t1, mut t2, mut t3, mut t4, mut t5, mut t6, mut t7) = bs;
 
-    fn delta_swap(a: &mut u32x4, b: &mut u32x4, shift: u32, mask: u32x4) {
+    fn delta_swap(a: &mut u32x4, b: &mut u32x4, shift: u32, mask: u32) {
         // Per-u32-element shifts are sufficient for the actual masks used
         let t = (((*b) >> shift) ^ *a) & mask;
         *a = *a ^ t;
@@ -531,7 +531,7 @@ pub fn un_bit_slice_1x128_with_u32x4(bs: Bs8State<u32x4>, output: &mut [u8]) {
 
     // Bit Index Swap 7 <-> 0:
     //     __ __ p0 __ __ __ __ __ __ b0 => __ __ b0 __ __ __ __ __ __ p0
-    let m0 = u32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
+    let m0 = 0x55555555;
     delta_swap(&mut t1, &mut t0, 1, m0);
     delta_swap(&mut t3, &mut t2, 1, m0);
     delta_swap(&mut t5, &mut t4, 1, m0);
@@ -539,7 +539,7 @@ pub fn un_bit_slice_1x128_with_u32x4(bs: Bs8State<u32x4>, output: &mut [u8]) {
 
     // Bit Index Swap 8 <-> 1:
     //     __ p1 __ __ __ __ __ __ b1 __ => __ b1 __ __ __ __ __ __ p1 __
-    let m1 = u32x4(0x33333333, 0x33333333, 0x33333333, 0x33333333);
+    let m1 = 0x33333333;
     delta_swap(&mut t2, &mut t0, 2, m1);
     delta_swap(&mut t3, &mut t1, 2, m1);
     delta_swap(&mut t6, &mut t4, 2, m1);
@@ -547,7 +547,7 @@ pub fn un_bit_slice_1x128_with_u32x4(bs: Bs8State<u32x4>, output: &mut [u8]) {
 
     // Bit Index Swap 9 <-> 2:
     //     p2 __ __ __ __ __ __ b2 __ __ => b2 __ __ __ __ __ __ p2 __ __
-    let m2 = u32x4(0x0F0F0F0F, 0x0F0F0F0F, 0x0F0F0F0F, 0x0F0F0F0F);
+    let m2 = 0x0F0F0F0F;
     delta_swap(&mut t4, &mut t0, 4, m2);
     delta_swap(&mut t5, &mut t1, 4, m2);
     delta_swap(&mut t6, &mut t2, 4, m2);

--- a/aes/aes-soft/src/bitslice.rs
+++ b/aes/aes-soft/src/bitslice.rs
@@ -421,7 +421,7 @@ pub fn un_bit_slice_1x16_with_u16(bs: &Bs8State<u16>, output: &mut [u8]) {
 pub fn bit_slice_1x128_with_u32x4(data: &[u8]) -> Bs8State<u32x4> {
     // Bitslicing is a bit index manipulation. 1024 bits of data means each bit is positioned at a
     // 10-bit index. AES data is 8 blocks, each one a 4x4 column-major matrix of bytes, so the
-    // index is initially:
+    // index is initially ([b]lock, [c]olumn, [r]ow, [p]osition):
     //     b2 b1 b0 c1 c0 r1 r0 p2 p1 p0
     //
     // The desired bitsliced data groups first by bit position, then row, column, block:
@@ -512,7 +512,7 @@ pub fn bit_slice_fill_4x4_with_u32x4(a: u32, b: u32, c: u32, d: u32) -> Bs8State
 pub fn un_bit_slice_1x128_with_u32x4(bs: Bs8State<u32x4>, output: &mut [u8]) {
     // Unbitslicing is a bit index manipulation. 1024 bits of data means each bit is positioned at
     // a 10-bit index. AES data is 8 blocks, each one a 4x4 column-major matrix of bytes, so the
-    // desired index for the output is:
+    // desired index for the output is ([b]lock, [c]olumn, [r]ow, [p]osition):
     //     b2 b1 b0 c1 c0 r1 r0 p2 p1 p0
     //
     // The initially bitsliced data groups first by bit position, then row, column, block:

--- a/aes/aes-soft/src/bitslice.rs
+++ b/aes/aes-soft/src/bitslice.rs
@@ -461,6 +461,7 @@ pub fn bit_slice_1x128_with_u32x4(data: &[u8]) -> Bs8State<u32x4> {
 
     fn delta_swap(a: &mut u32x4, b: &mut u32x4, shift: u32, mask: u32) {
         // Per-u32-element shifts are sufficient for actual masks used
+        debug_assert_eq!(mask, (mask << shift) >> shift);
         let t = (((*b) >> shift) ^ *a) & mask;
         *a = *a ^ t;
         *b = *b ^ (t << shift);
@@ -522,6 +523,7 @@ pub fn un_bit_slice_1x128_with_u32x4(bs: Bs8State<u32x4>, output: &mut [u8]) {
 
     fn delta_swap(a: &mut u32x4, b: &mut u32x4, shift: u32, mask: u32) {
         // Per-u32-element shifts are sufficient for the actual masks used
+        debug_assert_eq!(mask, (mask << shift) >> shift);
         let t = (((*b) >> shift) ^ *a) & mask;
         *a = *a ^ t;
         *b = *b ^ (t << shift);

--- a/aes/aes-soft/src/simd.rs
+++ b/aes/aes-soft/src/simd.rs
@@ -32,6 +32,15 @@ impl BitAnd for u32x4 {
     }
 }
 
+impl BitAnd<u32> for u32x4 {
+    type Output = u32x4;
+
+    #[inline(always)]
+    fn bitand(self, rhs: u32) -> u32x4 {
+        u32x4(self.0 & rhs, self.1 & rhs, self.2 & rhs, self.3 & rhs)
+    }
+}
+
 impl BitOr for u32x4 {
     type Output = u32x4;
 

--- a/aes/aes-soft/src/simd.rs
+++ b/aes/aes-soft/src/simd.rs
@@ -1,4 +1,4 @@
-use core::ops::{BitAnd, BitOr, BitXor};
+use core::ops::{BitAnd, BitOr, BitXor, Shl, Shr};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
@@ -42,6 +42,34 @@ impl BitOr for u32x4 {
             self.1 | rhs.1,
             self.2 | rhs.2,
             self.3 | rhs.3,
+        )
+    }
+}
+
+impl Shl<u32> for u32x4 {
+    type Output = u32x4;
+
+    #[inline(always)]
+    fn shl(self, shift: u32) -> u32x4 {
+        u32x4(
+            self.0 << shift,
+            self.1 << shift,
+            self.2 << shift,
+            self.3 << shift,
+        )
+    }
+}
+
+impl Shr<u32> for u32x4 {
+    type Output = u32x4;
+
+    #[inline(always)]
+    fn shr(self, shift: u32) -> u32x4 {
+        u32x4(
+            self.0 >> shift,
+            self.1 >> shift,
+            self.2 >> shift,
+            self.3 >> shift,
         )
     }
 }


### PR DESCRIPTION
Uses a more efficient algorithm for:
- bit_slice_1x128_with_u32x4
- un_bit_slice_1x128_with_u32x4

Bit slicing can appear as an opaque series of magical masking and shifting, so I've also added comments explaining the algorithm in terms of bit index manipulation.

According to the benchmarks, the overall performance improvement is a few percent. It would be nice to benchmark the (un)bitslicing specifically, but I'm a relative rust beginner, so if anyone could help me setting that up, it would be much appreciated.