### PR TITLE
[WIP] Prototype of bitsliced AES using Bs8State<u32>

### DIFF
--- a/aes/aes-soft/src/bitslice.rs
+++ b/aes/aes-soft/src/bitslice.rs
@@ -4,8 +4,8 @@
     clippy::unreadable_literal
 )]
 
-use crate::consts::U32X4_1;
-use crate::simd::u32x4;
+//use crate::consts::U32X4_1;
+//use crate::simd::u32x4;
 use byteorder::{ByteOrder, LE};
 use core::ops::{BitAnd, BitXor, Not};
 
@@ -417,6 +417,71 @@ pub fn un_bit_slice_1x16_with_u16(bs: &Bs8State<u16>, output: &mut [u8]) {
     LE::write_u32(&mut output[12..16], d);
 }
 
+// Bit Slice a 32 byte array of two 16 byte blocks. Each block is in column major order.
+pub fn bit_slice_1x32_with_u32(input: &[u8]) -> Bs8State<u32> {
+    // Bitslicing is a bit index manipulation. 256 bits of data means each bit is positioned at an
+    // 8-bit index. AES data is 2 blocks, each one a 4x4 column-major matrix of bytes, so the
+    // index is initially ([b]lock, [c]olumn, [r]ow, [p]osition):
+    //     b0 c1 c0 r1 r0 p2 p1 p0
+    //
+    // The desired bitsliced data groups first by bit position, then row, column, block:
+    //     p2 p1 p0 r1 r0 c1 c0 b0
+
+    #[rustfmt::skip]
+    fn read_column(input: &[u8]) -> u32 {
+        (u32::from(input[0])        ) |
+        (u32::from(input[1]) << 0x08) |
+        (u32::from(input[2]) << 0x10) |
+        (u32::from(input[3]) << 0x18)
+    }
+
+    // Interleave the columns on input (note the order of input)
+    //     b0 c1 c0 __ __ __ __ __ => c1 c0 b0 __ __ __ __ __
+    let mut t0 = read_column(&input[0x00..0x04]);
+    let mut t2 = read_column(&input[0x04..0x08]);
+    let mut t4 = read_column(&input[0x08..0x0C]);
+    let mut t6 = read_column(&input[0x0C..0x10]);
+    let mut t1 = read_column(&input[0x10..0x14]);
+    let mut t3 = read_column(&input[0x14..0x18]);
+    let mut t5 = read_column(&input[0x18..0x1C]);
+    let mut t7 = read_column(&input[0x1C..0x20]);
+
+    fn delta_swap(a: &mut u32, b: &mut u32, shift: u32, mask: u32) {
+        let t = (*a ^ ((*b) >> shift)) & mask;
+        *a ^= t;
+        *b ^= t << shift;
+    }
+
+    // Bit Index Swap 5 <-> 0:
+    //     __ __ b0 __ __ __ __ p0 => __ __ p0 __ __ __ __ b0
+    let m0 = 0x55555555;
+    delta_swap(&mut t1, &mut t0, 1, m0);
+    delta_swap(&mut t3, &mut t2, 1, m0);
+    delta_swap(&mut t5, &mut t4, 1, m0);
+    delta_swap(&mut t7, &mut t6, 1, m0);
+
+    // Bit Index Swap 6 <-> 1:
+    //     __ c0 __ __ __ __ p1 __ => __ p1 __ __ __ __ c0 __
+    let m1 = 0x33333333;
+    delta_swap(&mut t2, &mut t0, 2, m1);
+    delta_swap(&mut t3, &mut t1, 2, m1);
+    delta_swap(&mut t6, &mut t4, 2, m1);
+    delta_swap(&mut t7, &mut t5, 2, m1);
+
+    // Bit Index Swap 7 <-> 2:
+    //     c1 __ __ __ __ p2 __ __ => p2 __ __ __ __ c1 __ __
+    let m2 = 0x0F0F0F0F;
+    delta_swap(&mut t4, &mut t0, 4, m2);
+    delta_swap(&mut t5, &mut t1, 4, m2);
+    delta_swap(&mut t6, &mut t2, 4, m2);
+    delta_swap(&mut t7, &mut t3, 4, m2);
+
+    // Final bitsliced bit index, as desired:
+    //     p2 p1 p0 r1 r0 c1 c0 b0
+    Bs8State(t0, t1, t2, t3, t4, t5, t6, t7)
+}
+
+/*
 // Bit Slice a 128 byte array of eight 16 byte blocks. Each block is in column major order.
 pub fn bit_slice_1x128_with_u32x4(data: &[u8]) -> Bs8State<u32x4> {
     let bit0 = u32x4(0x01010101, 0x01010101, 0x01010101, 0x01010101);
@@ -525,7 +590,22 @@ pub fn bit_slice_1x128_with_u32x4(data: &[u8]) -> Bs8State<u32x4> {
 
     Bs8State(x0, x1, x2, x3, x4, x5, x6, x7)
 }
+*/
 
+// Bit slice a set of 4 u32s by filling a full 32 byte data block with those repeated values. This
+// is used as part of bit slicing the round keys.
+pub fn bit_slice_fill_4x4_with_u32(a: u32, b: u32, c: u32, d: u32) -> Bs8State<u32> {
+    let mut tmp = [0u8; 32];
+    for i in 0..2 {
+        LE::write_u32(&mut tmp[i * 16..i * 16 + 4], a);
+        LE::write_u32(&mut tmp[i * 16 + 4..i * 16 + 8], b);
+        LE::write_u32(&mut tmp[i * 16 + 8..i * 16 + 12], c);
+        LE::write_u32(&mut tmp[i * 16 + 12..i * 16 + 16], d);
+    }
+    bit_slice_1x32_with_u32(&tmp)
+}
+
+/*
 // Bit slice a set of 4 u32s by filling a full 128 byte data block with those repeated values. This
 // is used as part of bit slicing the round keys.
 pub fn bit_slice_fill_4x4_with_u32x4(a: u32, b: u32, c: u32, d: u32) -> Bs8State<u32x4> {
@@ -538,7 +618,76 @@ pub fn bit_slice_fill_4x4_with_u32x4(a: u32, b: u32, c: u32, d: u32) -> Bs8State
     }
     bit_slice_1x128_with_u32x4(&tmp)
 }
+*/
 
+// Un bit slice into a 32 byte buffer.
+pub fn un_bit_slice_1x32_with_u32(bs: Bs8State<u32>, output: &mut [u8]) {
+    // Unbitslicing is a bit index manipulation. 256 bits of data means each bit is positioned at
+    // an 8-bit index. AES data is 2 blocks, each one a 4x4 column-major matrix of bytes, so the
+    // desired index for the output is ([b]lock, [c]olumn, [r]ow, [p]osition):
+    //     b0 c1 c0 r1 r0 p2 p1 p0
+    //
+    // The initially bitsliced data groups first by bit position, then row, column, block:
+    //     p2 p1 p0 r1 r0 c1 c0 b0
+
+    let Bs8State(mut t0, mut t1, mut t2, mut t3, mut t4, mut t5, mut t6, mut t7) = bs;
+
+    fn delta_swap(a: &mut u32, b: &mut u32, shift: u32, mask: u32) {
+        let t = (*a ^ ((*b) >> shift)) & mask;
+        *a ^= t;
+        *b ^= t << shift;
+    }
+
+    // TODO: these bit index swaps are identical to those in bit_slice_1x32_with_u32
+
+    // Bit Index Swap 5 <-> 0:
+    //     __ __ p0 __ __ __ __ b0 => __ __ b0 __ __ __ __ p0
+    let m0 = 0x55555555;
+    delta_swap(&mut t1, &mut t0, 1, m0);
+    delta_swap(&mut t3, &mut t2, 1, m0);
+    delta_swap(&mut t5, &mut t4, 1, m0);
+    delta_swap(&mut t7, &mut t6, 1, m0);
+
+    // Bit Index Swap 6 <-> 1:
+    //     __ p1 __ __ __ __ c0 __ => __ c0 __ __ __ __ p1 __
+    let m1 = 0x33333333;
+    delta_swap(&mut t2, &mut t0, 2, m1);
+    delta_swap(&mut t3, &mut t1, 2, m1);
+    delta_swap(&mut t6, &mut t4, 2, m1);
+    delta_swap(&mut t7, &mut t5, 2, m1);
+
+    // Bit Index Swap 7 <-> 2:
+    //     p2 __ __ __ __ c1 __ __ => c1 __ __ __ __ p2 __ __
+    let m2 = 0x0F0F0F0F;
+    delta_swap(&mut t4, &mut t0, 4, m2);
+    delta_swap(&mut t5, &mut t1, 4, m2);
+    delta_swap(&mut t6, &mut t2, 4, m2);
+    delta_swap(&mut t7, &mut t3, 4, m2);
+
+    #[rustfmt::skip]
+    fn write_column(column: u32, output: &mut [u8]) {
+        output[0] = (column        ) as u8;
+        output[1] = (column >> 0x08) as u8;
+        output[2] = (column >> 0x10) as u8;
+        output[3] = (column >> 0x18) as u8;
+    }
+
+    // De-interleave the columns on output (note the order of output)
+    //     c1 c0 b0 __ __ __ __ __ => b0 c1 c0 __ __ __ __ __
+    write_column(t0, &mut output[0x00..0x04]);
+    write_column(t2, &mut output[0x04..0x08]);
+    write_column(t4, &mut output[0x08..0x0C]);
+    write_column(t6, &mut output[0x0C..0x10]);
+    write_column(t1, &mut output[0x10..0x14]);
+    write_column(t3, &mut output[0x14..0x18]);
+    write_column(t5, &mut output[0x18..0x1C]);
+    write_column(t7, &mut output[0x1C..0x20]);
+
+    // Final AES bit index, as desired:
+    //     b0 c1 c0 r1 r0 p2 p1 p0
+}
+
+/*
 // Un bit slice into a 128 byte buffer.
 pub fn un_bit_slice_1x128_with_u32x4(bs: Bs8State<u32x4>, output: &mut [u8]) {
     let Bs8State(t0, t1, t2, t3, t4, t5, t6, t7) = bs;
@@ -648,6 +797,7 @@ pub fn un_bit_slice_1x128_with_u32x4(bs: Bs8State<u32x4>, output: &mut [u8]) {
     write_row_major(x6, &mut output[96..112]);
     write_row_major(x7, &mut output[112..128])
 }
+*/
 
 // The Gf2Ops, Gf4Ops, and Gf8Ops traits specify the functions needed to calculate the AES S-Box
 // values. This particuar implementation of those S-Box values is taken from [7], so that is where
@@ -916,20 +1066,20 @@ pub trait AesBitValueOps:
 
 // The bits of 'x' selected by 'm' are swapped with those selected by '(m << s)'.
 // Requires that 'm & (m << s) == 0' (no overlap) and '((m << s) >> s) == m' (no loss).
-fn delta_swap(x: u16, m: u16, s: u16) -> u16 {
+fn delta_swap_u16(x: u16, m: u16, s: u16) -> u16 {
     let t = (x ^ (x >> s)) & m;
     x ^ (t ^ (t << s))
 }
 
 impl AesBitValueOps for u16 {
     fn shift_row(self) -> u16 {
-        let temp = delta_swap(self, 0x2310, 2);
-        delta_swap(temp, 0x5050, 1)
+        let temp = delta_swap_u16(self, 0x2310, 2);
+        delta_swap_u16(temp, 0x5050, 1)
     }
 
     fn inv_shift_row(self) -> u16 {
-        let temp = delta_swap(self, 0x5050, 1);
-        delta_swap(temp, 0x2310, 2)
+        let temp = delta_swap_u16(self, 0x5050, 1);
+        delta_swap_u16(temp, 0x2310, 2)
     }
 
     fn ror1(self) -> u16 {
@@ -941,6 +1091,34 @@ impl AesBitValueOps for u16 {
     }
 }
 
+// The bits of 'x' selected by 'm' are swapped with those selected by '(m << s)'.
+// Requires that 'm & (m << s) == 0' (no overlap) and '((m << s) >> s) == m' (no loss).
+fn delta_swap_u32(x: u32, m: u32, s: u32) -> u32 {
+    let t = (x ^ (x >> s)) & m;
+    x ^ (t ^ (t << s))
+}
+
+impl AesBitValueOps for u32 {
+    fn shift_row(self) -> u32 {
+        let temp = delta_swap_u32(self, 0x0C0F0300, 4);
+        delta_swap_u32(temp, 0x33003300, 2)
+    }
+
+    fn inv_shift_row(self) -> u32 {
+        let temp = delta_swap_u32(self, 0x33003300, 2);
+        delta_swap_u32(temp, 0x0C0F0300, 4)
+    }
+
+    fn ror1(self) -> u32 {
+        self.rotate_right(8)
+    }
+
+    fn ror2(self) -> u32 {
+        self.rotate_right(16)
+    }
+}
+
+/*
 impl u32x4 {
     fn lsh(self, s: u32) -> u32x4 {
         let u32x4(a0, a1, a2, a3) = self;
@@ -1008,3 +1186,4 @@ impl AesBitValueOps for u32x4 {
         u32x4(a2, a3, a0, a1)
     }
 }
+*/

--- a/aes/aes-soft/src/consts.rs
+++ b/aes/aes-soft/src/consts.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::unreadable_literal)]
 
-use crate::simd::u32x4;
+//use crate::simd::u32x4;
 
-pub const U32X4_0: u32x4 = u32x4(0, 0, 0, 0);
-pub const U32X4_1: u32x4 = u32x4(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+//pub const U32X4_0: u32x4 = u32x4(0, 0, 0, 0);
+//pub const U32X4_1: u32x4 = u32x4(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
 
 // This array is not accessed in any key-dependant way, so there are no timing problems inherent in
 // using it.


### PR DESCRIPTION
Passes the aes-soft tests and gives better benchmarks on my haswell laptop than the 8-block `Bs8State<u32x4>` version, although I'm not sure if I have SIMD properly configured there (I at least have avx on).

As written, this replaces the `Bs8State<u32x4>` version, retaining the 8-block parallel API, but it's natural parallelism is just 2 blocks. Ideally it would be a configurable option but I'm not sure how to go about setting that up.