### PR TITLE
[WIP] Prototype of bitsliced AES using Bs8State<u64>

### DIFF
--- a/aes/aes-soft/src/consts.rs
+++ b/aes/aes-soft/src/consts.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::unreadable_literal)]
 
-use crate::simd::u32x4;
+//use crate::simd::u32x4;
 
-pub const U32X4_0: u32x4 = u32x4(0, 0, 0, 0);
-pub const U32X4_1: u32x4 = u32x4(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+//pub const U32X4_0: u32x4 = u32x4(0, 0, 0, 0);
+//pub const U32X4_1: u32x4 = u32x4(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
 
 // This array is not accessed in any key-dependant way, so there are no timing problems inherent in
 // using it.

--- a/aes/aes-soft/src/impls.rs
+++ b/aes/aes-soft/src/impls.rs
@@ -2,21 +2,32 @@ pub use cipher::{BlockCipher, NewBlockCipher};
 
 use cipher::{
     consts::{U11, U13, U15, U16, U24, U32, U8},
+    //consts::{U11, U13, U15, U16, U24, U32, U4},
     generic_array::GenericArray,
 };
 
 use crate::{
     bitslice::{
-        bit_slice_1x128_with_u32x4, bit_slice_1x16_with_u16, bit_slice_4x4_with_u16,
-        bit_slice_fill_4x4_with_u32x4, decrypt_core, encrypt_core, un_bit_slice_1x128_with_u32x4,
-        un_bit_slice_1x16_with_u16, Bs8State,
+        //bit_slice_1x128_with_u32x4,
+        bit_slice_1x16_with_u16,
+        bit_slice_1x64_with_u64,
+        bit_slice_4x4_with_u16,
+        bit_slice_fill_4x4_with_u64,
+        //bit_slice_fill_4x4_with_u32x4,
+        decrypt_core,
+        encrypt_core,
+        //un_bit_slice_1x128_with_u32x4,
+        un_bit_slice_1x16_with_u16,
+        un_bit_slice_1x64_with_u64,
+        Bs8State,
     },
-    consts::U32X4_0,
+    //consts::U32X4_0,
     expand::expand_key,
-    simd::u32x4,
+    //simd::u32x4,
 };
 
 pub type Block128 = GenericArray<u8, U16>;
+//pub type Block128x4 = GenericArray<GenericArray<u8, U16>, U4>;
 pub type Block128x8 = GenericArray<GenericArray<u8, U16>, U8>;
 
 macro_rules! define_aes_impl {
@@ -32,8 +43,10 @@ macro_rules! define_aes_impl {
         pub struct $name {
             enc_keys: [Bs8State<u16>; $rounds],
             dec_keys: [Bs8State<u16>; $rounds],
-            enc_keys8: [Bs8State<u32x4>; $rounds],
-            dec_keys8: [Bs8State<u32x4>; $rounds],
+            enc_keys4: [Bs8State<u64>; $rounds],
+            dec_keys4: [Bs8State<u64>; $rounds],
+            //enc_keys8: [Bs8State<u32x4>; $rounds],
+            //dec_keys8: [Bs8State<u32x4>; $rounds],
         }
 
         impl NewBlockCipher for $name {
@@ -42,15 +55,17 @@ macro_rules! define_aes_impl {
             #[inline]
             fn new(key: &GenericArray<u8, $key_size>) -> Self {
                 let (ek, dk) = expand_key::<$key_size, $rounds2>(key);
-                let k8 = Bs8State(
-                    U32X4_0, U32X4_0, U32X4_0, U32X4_0,
-                    U32X4_0, U32X4_0, U32X4_0, U32X4_0
-                );
+                //let k8 = Bs8State(
+                    //U32X4_0, U32X4_0, U32X4_0, U32X4_0,
+                    //U32X4_0, U32X4_0, U32X4_0, U32X4_0
+                //);
                 let mut c =  Self {
                     enc_keys: [Bs8State(0, 0, 0, 0, 0, 0, 0, 0); $rounds],
                     dec_keys: [Bs8State(0, 0, 0, 0, 0, 0, 0, 0); $rounds],
-                    enc_keys8: [k8; $rounds],
-                    dec_keys8: [k8; $rounds],
+                    enc_keys4: [Bs8State(0, 0, 0, 0, 0, 0, 0, 0); $rounds],
+                    dec_keys4: [Bs8State(0, 0, 0, 0, 0, 0, 0, 0); $rounds],
+                    //enc_keys8: [k8; $rounds],
+                    //dec_keys8: [k8; $rounds],
                 };
                 for i in 0..$rounds {
                     c.enc_keys[i] = bit_slice_4x4_with_u16(
@@ -59,12 +74,18 @@ macro_rules! define_aes_impl {
                     c.dec_keys[i] = bit_slice_4x4_with_u16(
                         dk[i][0], dk[i][1], dk[i][2], dk[i][3],
                     );
-                    c.enc_keys8[i] = bit_slice_fill_4x4_with_u32x4(
+                    c.enc_keys4[i] = bit_slice_fill_4x4_with_u64(
                         ek[i][0], ek[i][1], ek[i][2], ek[i][3],
                     );
-                    c.dec_keys8[i] = bit_slice_fill_4x4_with_u32x4(
+                    c.dec_keys4[i] = bit_slice_fill_4x4_with_u64(
                         dk[i][0], dk[i][1], dk[i][2], dk[i][3],
                     );
+                    //c.enc_keys8[i] = bit_slice_fill_4x4_with_u32x4(
+                        //ek[i][0], ek[i][1], ek[i][2], ek[i][3],
+                    //);
+                    //c.dec_keys8[i] = bit_slice_fill_4x4_with_u32x4(
+                        //dk[i][0], dk[i][1], dk[i][2], dk[i][3],
+                    //);
                 }
                 c
             }
@@ -73,6 +94,7 @@ macro_rules! define_aes_impl {
         impl BlockCipher for $name {
             type BlockSize = U16;
             type ParBlocks = U8;
+            //type ParBlocks = U4;
 
             #[inline]
             fn encrypt_block(&self, block: &mut Block128) {
@@ -88,6 +110,7 @@ macro_rules! define_aes_impl {
                 un_bit_slice_1x16_with_u16(&bs, block);
             }
 
+/*
             #[inline]
             fn encrypt_blocks(&self, blocks: &mut Block128x8) {
                 #[allow(unsafe_code)]
@@ -109,6 +132,59 @@ macro_rules! define_aes_impl {
                 let bs2 = decrypt_core(&bs, &self.dec_keys8);
                 un_bit_slice_1x128_with_u32x4(bs2, blocks);
             }
+*/
+
+            #[inline]
+            fn encrypt_blocks(&self, blocks: &mut Block128x8) {
+                #[allow(unsafe_code)]
+                let blocks: &mut [u8; 16*8] = unsafe {
+                    &mut *(blocks as *mut _ as *mut [u8; 128])
+                };
+                for pos in (0..128).step_by(64) {
+                    let blocks: &mut [u8] = &mut blocks[pos..(pos + 64)];
+                    let bs = bit_slice_1x64_with_u64(blocks);
+                    let bs2 = encrypt_core(&bs, &self.enc_keys4);
+                    un_bit_slice_1x64_with_u64(bs2, blocks);
+                }
+            }
+
+            #[inline]
+            fn decrypt_blocks(&self, blocks: &mut Block128x8) {
+                #[allow(unsafe_code)]
+                let blocks: &mut [u8; 16*8] = unsafe {
+                    &mut *(blocks as *mut _ as *mut [u8; 128])
+                };
+                for pos in (0..128).step_by(64) {
+                    let blocks: &mut [u8] = &mut blocks[pos..(pos + 64)];
+                    let bs = bit_slice_1x64_with_u64(blocks);
+                    let bs2 = decrypt_core(&bs, &self.dec_keys4);
+                    un_bit_slice_1x64_with_u64(bs2, blocks);
+                }
+            }
+
+/*
+            #[inline]
+            fn encrypt_blocks(&self, blocks: &mut Block128x4) {
+                #[allow(unsafe_code)]
+                let blocks: &mut [u8; 16*4] = unsafe {
+                    &mut *(blocks as *mut _ as *mut [u8; 64])
+                };
+                let bs = bit_slice_1x64_with_u64(blocks);
+                let bs2 = encrypt_core(&bs, &self.enc_keys4);
+                un_bit_slice_1x64_with_u64(bs2, blocks);
+            }
+
+            #[inline]
+            fn decrypt_blocks(&self, blocks: &mut Block128x4) {
+                #[allow(unsafe_code)]
+                let blocks: &mut [u8; 16*4] = unsafe {
+                    &mut *(blocks as *mut _ as *mut [u8; 64])
+                };
+                let bs = bit_slice_1x64_with_u64(blocks);
+                let bs2 = decrypt_core(&bs, &self.dec_keys4);
+                un_bit_slice_1x64_with_u64(bs2, blocks);
+            }
+*/
         }
 
         opaque_debug::implement!($name);


### PR DESCRIPTION
Passes the aes-soft tests and gives much better benchmarks on my haswell laptop than the 8-block `Bs8State<u32x4>` version (twice as fast as https://github.com/RustCrypto/block-ciphers/pull/172), although I'm not sure if I have SIMD properly configured there (I at least have avx on).

As written, this replaces the `Bs8State<u32x4>` version, retaining the 8-block parallel API, but it's natural parallelism is just 4 blocks. Ideally it would be a configurable option but I'm not sure how to go about setting that up.