### PR TITLE
aes-soft: fixslicing for AES-192 encryption

### DIFF
--- a/aes/aes-soft/benches/aes192.rs
+++ b/aes/aes-soft/benches/aes192.rs
@@ -2,7 +2,7 @@
 extern crate test;
 
 use aes_soft::cipher::{BlockCipher, NewBlockCipher};
-use aes_soft::Aes192;
+use aes_soft::{Aes192, Aes192Fixsliced};
 
 #[bench]
 pub fn aes192_encrypt(bh: &mut test::Bencher) {
@@ -31,6 +31,18 @@ pub fn aes192_decrypt(bh: &mut test::Bencher) {
 #[bench]
 pub fn aes192_encrypt8(bh: &mut test::Bencher) {
     let cipher = Aes192::new(&Default::default());
+    let mut input = Default::default();
+
+    bh.iter(|| {
+        cipher.encrypt_blocks(&mut input);
+        test::black_box(&input);
+    });
+    bh.bytes = (input[0].len() * input.len()) as u64;
+}
+
+#[bench]
+pub fn aes192_encrypt2_fixsliced(bh: &mut test::Bencher) {
+    let cipher = Aes192Fixsliced::new(&Default::default());
     let mut input = Default::default();
 
     bh.iter(|| {

--- a/aes/aes-soft/src/lib.rs
+++ b/aes/aes-soft/src/lib.rs
@@ -51,6 +51,6 @@ mod impls;
 mod simd;
 
 pub use crate::{
-    fixslice::{Aes128Fixsliced, Aes256Fixsliced},
+    fixslice::{Aes128Fixsliced, Aes192Fixsliced, Aes256Fixsliced},
     impls::{Aes128, Aes192, Aes256},
 };

--- a/aes/aes-soft/tests/lib.rs
+++ b/aes/aes-soft/tests/lib.rs
@@ -90,4 +90,5 @@ macro_rules! new_encrypt_only_test {
 }
 
 new_encrypt_only_test!(aes128_fixsliced_test, "aes128", aes_soft::Aes128Fixsliced);
+new_encrypt_only_test!(aes192_fixsliced_test, "aes192", aes_soft::Aes192Fixsliced);
 new_encrypt_only_test!(aes256_fixsliced_test, "aes256", aes_soft::Aes256Fixsliced);


### PR DESCRIPTION
@tarcieri I figured it's easier to PR this against the current master and let you integrate it into #176 .