### PR TITLE
aes-soft v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "byteorder",
  "cipher",

--- a/aes/aes-soft/CHANGELOG.md
+++ b/aes/aes-soft/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2020-10-26)
+### Changed
+- Use fixslicing for AES encryption - 3X performance boost ([#174], [#176], [#177])
+- Additional bitslicing performance optimizations ([#171], [#175])
+
+[#177]: https://github.com/RustCrypto/block-ciphers/pull/177
+[#176]: https://github.com/RustCrypto/block-ciphers/pull/176
+[#175]: https://github.com/RustCrypto/block-ciphers/pull/175
+[#174]: https://github.com/RustCrypto/block-ciphers/pull/174
+[#171]: https://github.com/RustCrypto/block-ciphers/pull/171
+
 ## 0.6.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-soft"
-version = "0.6.0"
+version = "0.6.1"
 description = "AES (Rijndael) block ciphers bit-sliced implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Use fixslicing for AES encryption - 3X performance boost ([#174], [#176], [#177])
- Additional bitslicing performance optimizations ([#171], [#175])

[#177]: https://github.com/RustCrypto/block-ciphers/pull/177
[#176]: https://github.com/RustCrypto/block-ciphers/pull/176
[#175]: https://github.com/RustCrypto/block-ciphers/pull/175
[#174]: https://github.com/RustCrypto/block-ciphers/pull/174
[#171]: https://github.com/RustCrypto/block-ciphers/pull/171