### PR TITLE
aes-soft: CI for 32-bit Linux

### DIFF
--- a/.github/workflows/aes-soft.yml
+++ b/.github/workflows/aes-soft.yml
@@ -35,22 +35,34 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: cargo build --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - 1.41.0 # MSRV
-          - stable
+        include:
+          # 32-bit Linux
+          - target: i686-unknown-linux-gnu
+            rust: 1.41.0 # MSRV
+            deps: sudo apt install gcc-multilib
+          - target: i686-unknown-linux-gnu
+            rust: stable
+            deps: sudo apt install gcc-multilib
+
+          # 64-bit Linux
+          - target: x86_64-unknown-linux-gnu
+            rust: 1.41.0 # MSRV
+          - target: x86_64-unknown-linux-gnu
+            rust: stable
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
-      - run: cargo check --all-features
-      - run: cargo test --no-default-features
-      - run: cargo test
-      - run: cargo test --all-features
-
+          target: ${{ matrix.target }}
+          override: true
+      - run: ${{ matrix.deps }}
+      - run: cargo check --target ${{ matrix.target }} --all-features
+      - run: cargo test --release --target ${{ matrix.target }}

--- a/aes/aes-soft/src/lib.rs
+++ b/aes/aes-soft/src/lib.rs
@@ -41,8 +41,6 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use cipher;
-
 mod bitslice;
 mod consts;
 mod expand;
@@ -56,6 +54,7 @@ mod impls;
 mod simd;
 
 pub use crate::impls::{Aes128, Aes192, Aes256};
+pub use cipher;
 
 /// 128-bit AES block
 pub type Block = cipher::generic_array::GenericArray<u8, cipher::consts::U16>;


### PR DESCRIPTION
Adds CI for the `i686-unknown-linux-gnu` platform