### PR TITLE
Improved AES fixslice MixColumns algorithm(s)

### DIFF
--- a/aes/aes-soft/src/fixslice32.rs
+++ b/aes/aes-soft/src/fixslice32.rs
@@ -587,184 +587,113 @@ fn sbox_nots(state: &mut [u32]) {
 
 /// Computation of the MixColumns transformation in the fixsliced representation
 /// used for rounds i s.t. (i%4) == 0.
+#[rustfmt::skip]
 fn mixcolumns_0(state: &mut State) {
-    let mut tmp3 = rotate_rows_1(rotate_columns_3(state[7]));
-    let tmp0 = state[7] ^ tmp3;
-    let mut tmp2 = state[1];
-    state[1] = state[0] ^ tmp0;
-    let mut tmp1 = rotate_rows_1(rotate_columns_3(state[0]));
-    state[1] ^= tmp1;
-    state[0] ^= state[1];
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_3(tmp1));
-    state[0] ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp2));
-    state[1] ^= tmp1;
-    tmp2 ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_3(tmp1));
-    state[1] ^= tmp1;
-    tmp1 = state[2];
-    state[2] = tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= tmp2;
-    state[2] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_3(tmp2));
-    state[2] ^= tmp2;
-    tmp2 = state[3];
-    state[3] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= tmp1;
-    state[3] ^= tmp0 ^ tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_3(tmp1));
-    state[3] ^= tmp1;
-    tmp1 = state[4];
-    state[4] = tmp0 ^ tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= tmp2;
-    state[4] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_3(tmp2));
-    state[4] ^= tmp2;
-    tmp2 = state[5];
-    state[5] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= tmp1;
-    state[5] ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_3(tmp1));
-    state[5] ^= tmp1;
-    tmp1 = state[6];
-    state[6] = tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= tmp2;
-    state[6] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_3(tmp2));
-    state[6] ^= tmp2;
-    state[7] = tmp1;
-    state[7] ^= tmp3;
-    tmp3 = rotate_rows_1(rotate_columns_3(tmp3));
-    tmp3 ^= rotate_rows_1(rotate_columns_3(tmp3));
-    state[7] ^= tmp3;
+    let (a0, a1, a2, a3, a4, a5, a6, a7) = (
+        state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
+    );
+    let (b0, b1, b2, b3, b4, b5, b6, b7) = (
+        rotate_rows_and_columns_1_3(a0),
+        rotate_rows_and_columns_1_3(a1),
+        rotate_rows_and_columns_1_3(a2),
+        rotate_rows_and_columns_1_3(a3),
+        rotate_rows_and_columns_1_3(a4),
+        rotate_rows_and_columns_1_3(a5),
+        rotate_rows_and_columns_1_3(a6),
+        rotate_rows_and_columns_1_3(a7),
+    );
+    let (c0, c1, c2, c3, c4, c5, c6, c7) = (
+        a0 ^ b0,
+        a1 ^ b1,
+        a2 ^ b2,
+        a3 ^ b3,
+        a4 ^ b4,
+        a5 ^ b5,
+        a6 ^ b6,
+        a7 ^ b7,
+    );
+    state[0] = b0      ^ c7 ^ rotate_rows_and_columns_2_2(c0);
+    state[1] = b1 ^ c0 ^ c7 ^ rotate_rows_and_columns_2_2(c1);
+    state[2] = b2 ^ c1      ^ rotate_rows_and_columns_2_2(c2);
+    state[3] = b3 ^ c2 ^ c7 ^ rotate_rows_and_columns_2_2(c3);
+    state[4] = b4 ^ c3 ^ c7 ^ rotate_rows_and_columns_2_2(c4);
+    state[5] = b5 ^ c4      ^ rotate_rows_and_columns_2_2(c5);
+    state[6] = b6 ^ c5      ^ rotate_rows_and_columns_2_2(c6);
+    state[7] = b7 ^ c6      ^ rotate_rows_and_columns_2_2(c7);
 }
 
 /// Computation of the MixColumns transformation in the fixsliced representation
 /// used for round i s.t. (i%4) == 1.
+#[rustfmt::skip]
 fn mixcolumns_1(state: &mut State) {
-    let tmp0 = state[7] ^ rotate_rows_1(rotate_columns_2(state[7]));
-    let mut tmp1 = state[0] ^ rotate_rows_1(rotate_columns_2(state[0]));
-    let mut tmp2 = state[1];
-    state[1] = tmp1 ^ tmp0;
-    state[0] ^= state[1] ^ rotate_rows_2(tmp1);
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[1] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[1] ^= rotate_rows_2(tmp1);
-    tmp2 = state[2];
-    state[2] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[2] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[2] ^= rotate_rows_2(tmp1);
-    tmp2 = state[3];
-    state[3] = tmp1 ^ tmp0;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[3] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[3] ^= rotate_rows_2(tmp1);
-    tmp2 = state[4];
-    state[4] = tmp1 ^ tmp0;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[4] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[4] ^= rotate_rows_2(tmp1);
-    tmp2 = state[5];
-    state[5] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[5] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[5] ^= rotate_rows_2(tmp1);
-    tmp2 = state[6];
-    state[6] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[6] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[6] ^= rotate_rows_2(tmp1);
-    tmp2 = state[7];
-    state[7] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[7] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[7] ^= rotate_rows_2(tmp1);
+    let (a0, a1, a2, a3, a4, a5, a6, a7) = (
+        state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
+    );
+    let (b0, b1, b2, b3, b4, b5, b6, b7) = (
+        rotate_rows_and_columns_1_2(a0),
+        rotate_rows_and_columns_1_2(a1),
+        rotate_rows_and_columns_1_2(a2),
+        rotate_rows_and_columns_1_2(a3),
+        rotate_rows_and_columns_1_2(a4),
+        rotate_rows_and_columns_1_2(a5),
+        rotate_rows_and_columns_1_2(a6),
+        rotate_rows_and_columns_1_2(a7),
+    );
+    let (c0, c1, c2, c3, c4, c5, c6, c7) = (
+        a0 ^ b0,
+        a1 ^ b1,
+        a2 ^ b2,
+        a3 ^ b3,
+        a4 ^ b4,
+        a5 ^ b5,
+        a6 ^ b6,
+        a7 ^ b7,
+    );
+    state[0] = b0      ^ c7 ^ rotate_rows_2(c0);
+    state[1] = b1 ^ c0 ^ c7 ^ rotate_rows_2(c1);
+    state[2] = b2 ^ c1      ^ rotate_rows_2(c2);
+    state[3] = b3 ^ c2 ^ c7 ^ rotate_rows_2(c3);
+    state[4] = b4 ^ c3 ^ c7 ^ rotate_rows_2(c4);
+    state[5] = b5 ^ c4      ^ rotate_rows_2(c5);
+    state[6] = b6 ^ c5      ^ rotate_rows_2(c6);
+    state[7] = b7 ^ c6      ^ rotate_rows_2(c7);
 }
 
 /// Computation of the MixColumns transformation in the fixsliced representation
 /// used for rounds i s.t. (i%4) == 2.
+#[rustfmt::skip]
 fn mixcolumns_2(state: &mut State) {
-    let tmp0 = state[7] ^ rotate_rows_1(rotate_columns_1(state[7]));
-    let mut tmp2 = state[1];
-    state[1] = state[0] ^ tmp0;
-    let mut tmp1 = rotate_rows_1(rotate_columns_1(state[0]));
-    state[1] ^= tmp1;
-    state[0] ^= state[1];
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_1(tmp1));
-    state[0] ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp2));
-    state[1] ^= tmp1;
-    tmp2 ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_1(tmp1));
-    state[1] ^= tmp1;
-    tmp1 = state[2];
-    state[2] = tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= tmp2;
-    state[2] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_1(tmp2));
-    state[2] ^= tmp2;
-    tmp2 = state[3];
-    state[3] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= tmp1;
-    state[3] ^= tmp0 ^ tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_1(tmp1));
-    state[3] ^= tmp1;
-    tmp1 = state[4];
-    state[4] = tmp0 ^ tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= tmp2;
-    state[4] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_1(tmp2));
-    state[4] ^= tmp2;
-    tmp2 = state[5];
-    state[5] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= tmp1;
-    state[5] ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_1(tmp1));
-    state[5] ^= tmp1;
-    tmp1 = state[6];
-    state[6] = tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= tmp2;
-    state[6] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_1(tmp2));
-    state[6] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(state[7]));
-    state[7] = tmp1;
-    state[7] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_1(tmp2));
-    state[7] ^= tmp2;
+    let (a0, a1, a2, a3, a4, a5, a6, a7) = (
+        state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
+    );
+    let (b0, b1, b2, b3, b4, b5, b6, b7) = (
+        rotate_rows_and_columns_1_1(a0),
+        rotate_rows_and_columns_1_1(a1),
+        rotate_rows_and_columns_1_1(a2),
+        rotate_rows_and_columns_1_1(a3),
+        rotate_rows_and_columns_1_1(a4),
+        rotate_rows_and_columns_1_1(a5),
+        rotate_rows_and_columns_1_1(a6),
+        rotate_rows_and_columns_1_1(a7),
+    );
+    let (c0, c1, c2, c3, c4, c5, c6, c7) = (
+        a0 ^ b0,
+        a1 ^ b1,
+        a2 ^ b2,
+        a3 ^ b3,
+        a4 ^ b4,
+        a5 ^ b5,
+        a6 ^ b6,
+        a7 ^ b7,
+    );
+    state[0] = b0      ^ c7 ^ rotate_rows_and_columns_2_2(c0);
+    state[1] = b1 ^ c0 ^ c7 ^ rotate_rows_and_columns_2_2(c1);
+    state[2] = b2 ^ c1      ^ rotate_rows_and_columns_2_2(c2);
+    state[3] = b3 ^ c2 ^ c7 ^ rotate_rows_and_columns_2_2(c3);
+    state[4] = b4 ^ c3 ^ c7 ^ rotate_rows_and_columns_2_2(c4);
+    state[5] = b5 ^ c4      ^ rotate_rows_and_columns_2_2(c5);
+    state[6] = b6 ^ c5      ^ rotate_rows_and_columns_2_2(c6);
+    state[7] = b7 ^ c6      ^ rotate_rows_and_columns_2_2(c7);
 }
 
 /// Computation of the MixColumns transformation in the fixsliced representation
@@ -1065,4 +994,24 @@ fn rotate_rows_1(x: u32) -> u32 {
 #[inline(always)]
 fn rotate_rows_2(x: u32) -> u32 {
     ror(x, ror_distance(2, 0))
+}
+
+#[inline(always)]
+fn rotate_rows_and_columns_1_1(x: u32) -> u32 {
+    rotate_rows_1(rotate_columns_1(x))
+}
+
+#[inline(always)]
+fn rotate_rows_and_columns_1_2(x: u32) -> u32 {
+    rotate_rows_1(rotate_columns_2(x))
+}
+
+#[inline(always)]
+fn rotate_rows_and_columns_1_3(x: u32) -> u32 {
+    rotate_rows_1(rotate_columns_3(x))
+}
+
+#[inline(always)]
+fn rotate_rows_and_columns_2_2(x: u32) -> u32 {
+    rotate_rows_2(rotate_columns_2(x))
 }

--- a/aes/aes-soft/src/fixslice32.rs
+++ b/aes/aes-soft/src/fixslice32.rs
@@ -593,14 +593,14 @@ fn mixcolumns_0(state: &mut State) {
         state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
     );
     let (b0, b1, b2, b3, b4, b5, b6, b7) = (
-        rotate_rows_and_columns_1_3(a0),
-        rotate_rows_and_columns_1_3(a1),
-        rotate_rows_and_columns_1_3(a2),
-        rotate_rows_and_columns_1_3(a3),
-        rotate_rows_and_columns_1_3(a4),
-        rotate_rows_and_columns_1_3(a5),
-        rotate_rows_and_columns_1_3(a6),
-        rotate_rows_and_columns_1_3(a7),
+        rotate_rows_and_columns_1_1(a0),
+        rotate_rows_and_columns_1_1(a1),
+        rotate_rows_and_columns_1_1(a2),
+        rotate_rows_and_columns_1_1(a3),
+        rotate_rows_and_columns_1_1(a4),
+        rotate_rows_and_columns_1_1(a5),
+        rotate_rows_and_columns_1_1(a6),
+        rotate_rows_and_columns_1_1(a7),
     );
     let (c0, c1, c2, c3, c4, c5, c6, c7) = (
         a0 ^ b0,
@@ -667,14 +667,14 @@ fn mixcolumns_2(state: &mut State) {
         state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
     );
     let (b0, b1, b2, b3, b4, b5, b6, b7) = (
-        rotate_rows_and_columns_1_1(a0),
-        rotate_rows_and_columns_1_1(a1),
-        rotate_rows_and_columns_1_1(a2),
-        rotate_rows_and_columns_1_1(a3),
-        rotate_rows_and_columns_1_1(a4),
-        rotate_rows_and_columns_1_1(a5),
-        rotate_rows_and_columns_1_1(a6),
-        rotate_rows_and_columns_1_1(a7),
+        rotate_rows_and_columns_1_3(a0),
+        rotate_rows_and_columns_1_3(a1),
+        rotate_rows_and_columns_1_3(a2),
+        rotate_rows_and_columns_1_3(a3),
+        rotate_rows_and_columns_1_3(a4),
+        rotate_rows_and_columns_1_3(a5),
+        rotate_rows_and_columns_1_3(a6),
+        rotate_rows_and_columns_1_3(a7),
     );
     let (c0, c1, c2, c3, c4, c5, c6, c7) = (
         a0 ^ b0,
@@ -971,21 +971,6 @@ fn ror_distance(rows: u32, cols: u32) -> u32 {
     (rows << 3) + (cols << 1)
 }
 
-#[inline]
-fn rotate_columns_1(x: u32) -> u32 {
-    ((x >> 6) & 0x03030303) | ((x & 0x3f3f3f3f) << 2)
-}
-
-#[inline]
-fn rotate_columns_2(x: u32) -> u32 {
-    ((x >> 4) & 0x0f0f0f0f) | ((x & 0x0f0f0f0f) << 4)
-}
-
-#[inline]
-fn rotate_columns_3(x: u32) -> u32 {
-    ((x >> 2) & 0x3f3f3f3f) | ((x & 0x03030303) << 6)
-}
-
 #[inline(always)]
 fn rotate_rows_1(x: u32) -> u32 {
     ror(x, ror_distance(1, 0))
@@ -997,21 +982,29 @@ fn rotate_rows_2(x: u32) -> u32 {
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 fn rotate_rows_and_columns_1_1(x: u32) -> u32 {
-    rotate_rows_1(rotate_columns_1(x))
+    (ror(x, ror_distance(1, 1)) & 0x3f3f3f3f) |
+    (ror(x, ror_distance(0, 1)) & 0xc0c0c0c0)
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 fn rotate_rows_and_columns_1_2(x: u32) -> u32 {
-    rotate_rows_1(rotate_columns_2(x))
+    (ror(x, ror_distance(1, 2)) & 0x0f0f0f0f) |
+    (ror(x, ror_distance(0, 2)) & 0xf0f0f0f0)
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 fn rotate_rows_and_columns_1_3(x: u32) -> u32 {
-    rotate_rows_1(rotate_columns_3(x))
+    (ror(x, ror_distance(1, 3)) & 0x03030303) |
+    (ror(x, ror_distance(0, 3)) & 0xfcfcfcfc)
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 fn rotate_rows_and_columns_2_2(x: u32) -> u32 {
-    rotate_rows_2(rotate_columns_2(x))
+    (ror(x, ror_distance(2, 2)) & 0x0f0f0f0f) |
+    (ror(x, ror_distance(1, 2)) & 0xf0f0f0f0)
 }

--- a/aes/aes-soft/src/fixslice64.rs
+++ b/aes/aes-soft/src/fixslice64.rs
@@ -605,184 +605,113 @@ fn sbox_nots(state: &mut [u64]) {
 
 /// Computation of the MixColumns transformation in the fixsliced representation
 /// used for rounds i s.t. (i%4) == 0.
+#[rustfmt::skip]
 fn mixcolumns_0(state: &mut State) {
-    let mut tmp3 = rotate_rows_1(rotate_columns_3(state[7]));
-    let tmp0 = state[7] ^ tmp3;
-    let mut tmp2 = state[1];
-    state[1] = state[0] ^ tmp0;
-    let mut tmp1 = rotate_rows_1(rotate_columns_3(state[0]));
-    state[1] ^= tmp1;
-    state[0] ^= state[1];
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_3(tmp1));
-    state[0] ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp2));
-    state[1] ^= tmp1;
-    tmp2 ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_3(tmp1));
-    state[1] ^= tmp1;
-    tmp1 = state[2];
-    state[2] = tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= tmp2;
-    state[2] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_3(tmp2));
-    state[2] ^= tmp2;
-    tmp2 = state[3];
-    state[3] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= tmp1;
-    state[3] ^= tmp0 ^ tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_3(tmp1));
-    state[3] ^= tmp1;
-    tmp1 = state[4];
-    state[4] = tmp0 ^ tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= tmp2;
-    state[4] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_3(tmp2));
-    state[4] ^= tmp2;
-    tmp2 = state[5];
-    state[5] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= tmp1;
-    state[5] ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_3(tmp1));
-    state[5] ^= tmp1;
-    tmp1 = state[6];
-    state[6] = tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp1));
-    tmp1 ^= tmp2;
-    state[6] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_3(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_3(tmp2));
-    state[6] ^= tmp2;
-    state[7] = tmp1;
-    state[7] ^= tmp3;
-    tmp3 = rotate_rows_1(rotate_columns_3(tmp3));
-    tmp3 ^= rotate_rows_1(rotate_columns_3(tmp3));
-    state[7] ^= tmp3;
+    let (a0, a1, a2, a3, a4, a5, a6, a7) = (
+        state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
+    );
+    let (b0, b1, b2, b3, b4, b5, b6, b7) = (
+        rotate_rows_and_columns_1_3(a0),
+        rotate_rows_and_columns_1_3(a1),
+        rotate_rows_and_columns_1_3(a2),
+        rotate_rows_and_columns_1_3(a3),
+        rotate_rows_and_columns_1_3(a4),
+        rotate_rows_and_columns_1_3(a5),
+        rotate_rows_and_columns_1_3(a6),
+        rotate_rows_and_columns_1_3(a7),
+    );
+    let (c0, c1, c2, c3, c4, c5, c6, c7) = (
+        a0 ^ b0,
+        a1 ^ b1,
+        a2 ^ b2,
+        a3 ^ b3,
+        a4 ^ b4,
+        a5 ^ b5,
+        a6 ^ b6,
+        a7 ^ b7,
+    );
+    state[0] = b0      ^ c7 ^ rotate_rows_and_columns_2_2(c0);
+    state[1] = b1 ^ c0 ^ c7 ^ rotate_rows_and_columns_2_2(c1);
+    state[2] = b2 ^ c1      ^ rotate_rows_and_columns_2_2(c2);
+    state[3] = b3 ^ c2 ^ c7 ^ rotate_rows_and_columns_2_2(c3);
+    state[4] = b4 ^ c3 ^ c7 ^ rotate_rows_and_columns_2_2(c4);
+    state[5] = b5 ^ c4      ^ rotate_rows_and_columns_2_2(c5);
+    state[6] = b6 ^ c5      ^ rotate_rows_and_columns_2_2(c6);
+    state[7] = b7 ^ c6      ^ rotate_rows_and_columns_2_2(c7);
 }
 
 /// Computation of the MixColumns transformation in the fixsliced representation
 /// used for round i s.t. (i%4) == 1.
+#[rustfmt::skip]
 fn mixcolumns_1(state: &mut State) {
-    let tmp0 = state[7] ^ rotate_rows_1(rotate_columns_2(state[7]));
-    let mut tmp1 = state[0] ^ rotate_rows_1(rotate_columns_2(state[0]));
-    let mut tmp2 = state[1];
-    state[1] = tmp1 ^ tmp0;
-    state[0] ^= state[1] ^ rotate_rows_2(tmp1);
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[1] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[1] ^= rotate_rows_2(tmp1);
-    tmp2 = state[2];
-    state[2] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[2] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[2] ^= rotate_rows_2(tmp1);
-    tmp2 = state[3];
-    state[3] = tmp1 ^ tmp0;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[3] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[3] ^= rotate_rows_2(tmp1);
-    tmp2 = state[4];
-    state[4] = tmp1 ^ tmp0;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[4] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[4] ^= rotate_rows_2(tmp1);
-    tmp2 = state[5];
-    state[5] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[5] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[5] ^= rotate_rows_2(tmp1);
-    tmp2 = state[6];
-    state[6] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[6] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[6] ^= rotate_rows_2(tmp1);
-    tmp2 = state[7];
-    state[7] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_2(tmp2));
-    state[7] ^= tmp1;
-    tmp1 ^= tmp2;
-    state[7] ^= rotate_rows_2(tmp1);
+    let (a0, a1, a2, a3, a4, a5, a6, a7) = (
+        state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
+    );
+    let (b0, b1, b2, b3, b4, b5, b6, b7) = (
+        rotate_rows_and_columns_1_2(a0),
+        rotate_rows_and_columns_1_2(a1),
+        rotate_rows_and_columns_1_2(a2),
+        rotate_rows_and_columns_1_2(a3),
+        rotate_rows_and_columns_1_2(a4),
+        rotate_rows_and_columns_1_2(a5),
+        rotate_rows_and_columns_1_2(a6),
+        rotate_rows_and_columns_1_2(a7),
+    );
+    let (c0, c1, c2, c3, c4, c5, c6, c7) = (
+        a0 ^ b0,
+        a1 ^ b1,
+        a2 ^ b2,
+        a3 ^ b3,
+        a4 ^ b4,
+        a5 ^ b5,
+        a6 ^ b6,
+        a7 ^ b7,
+    );
+    state[0] = b0      ^ c7 ^ rotate_rows_2(c0);
+    state[1] = b1 ^ c0 ^ c7 ^ rotate_rows_2(c1);
+    state[2] = b2 ^ c1      ^ rotate_rows_2(c2);
+    state[3] = b3 ^ c2 ^ c7 ^ rotate_rows_2(c3);
+    state[4] = b4 ^ c3 ^ c7 ^ rotate_rows_2(c4);
+    state[5] = b5 ^ c4      ^ rotate_rows_2(c5);
+    state[6] = b6 ^ c5      ^ rotate_rows_2(c6);
+    state[7] = b7 ^ c6      ^ rotate_rows_2(c7);
 }
 
 /// Computation of the MixColumns transformation in the fixsliced representation
 /// used for rounds i s.t. (i%4) == 2.
+#[rustfmt::skip]
 fn mixcolumns_2(state: &mut State) {
-    let tmp0 = state[7] ^ rotate_rows_1(rotate_columns_1(state[7]));
-    let mut tmp2 = state[1];
-    state[1] = state[0] ^ tmp0;
-    let mut tmp1 = rotate_rows_1(rotate_columns_1(state[0]));
-    state[1] ^= tmp1;
-    state[0] ^= state[1];
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_1(tmp1));
-    state[0] ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp2));
-    state[1] ^= tmp1;
-    tmp2 ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_1(tmp1));
-    state[1] ^= tmp1;
-    tmp1 = state[2];
-    state[2] = tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= tmp2;
-    state[2] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_1(tmp2));
-    state[2] ^= tmp2;
-    tmp2 = state[3];
-    state[3] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= tmp1;
-    state[3] ^= tmp0 ^ tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_1(tmp1));
-    state[3] ^= tmp1;
-    tmp1 = state[4];
-    state[4] = tmp0 ^ tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= tmp2;
-    state[4] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_1(tmp2));
-    state[4] ^= tmp2;
-    tmp2 = state[5];
-    state[5] = tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= tmp1;
-    state[5] ^= tmp1;
-    tmp1 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= rotate_rows_1(rotate_columns_1(tmp1));
-    state[5] ^= tmp1;
-    tmp1 = state[6];
-    state[6] = tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp1));
-    tmp1 ^= tmp2;
-    state[6] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_1(tmp2));
-    state[6] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(state[7]));
-    state[7] = tmp1;
-    state[7] ^= tmp2;
-    tmp2 = rotate_rows_1(rotate_columns_1(tmp2));
-    tmp2 ^= rotate_rows_1(rotate_columns_1(tmp2));
-    state[7] ^= tmp2;
+    let (a0, a1, a2, a3, a4, a5, a6, a7) = (
+        state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
+    );
+    let (b0, b1, b2, b3, b4, b5, b6, b7) = (
+        rotate_rows_and_columns_1_1(a0),
+        rotate_rows_and_columns_1_1(a1),
+        rotate_rows_and_columns_1_1(a2),
+        rotate_rows_and_columns_1_1(a3),
+        rotate_rows_and_columns_1_1(a4),
+        rotate_rows_and_columns_1_1(a5),
+        rotate_rows_and_columns_1_1(a6),
+        rotate_rows_and_columns_1_1(a7),
+    );
+    let (c0, c1, c2, c3, c4, c5, c6, c7) = (
+        a0 ^ b0,
+        a1 ^ b1,
+        a2 ^ b2,
+        a3 ^ b3,
+        a4 ^ b4,
+        a5 ^ b5,
+        a6 ^ b6,
+        a7 ^ b7,
+    );
+    state[0] = b0      ^ c7 ^ rotate_rows_and_columns_2_2(c0);
+    state[1] = b1 ^ c0 ^ c7 ^ rotate_rows_and_columns_2_2(c1);
+    state[2] = b2 ^ c1      ^ rotate_rows_and_columns_2_2(c2);
+    state[3] = b3 ^ c2 ^ c7 ^ rotate_rows_and_columns_2_2(c3);
+    state[4] = b4 ^ c3 ^ c7 ^ rotate_rows_and_columns_2_2(c4);
+    state[5] = b5 ^ c4      ^ rotate_rows_and_columns_2_2(c5);
+    state[6] = b6 ^ c5      ^ rotate_rows_and_columns_2_2(c6);
+    state[7] = b7 ^ c6      ^ rotate_rows_and_columns_2_2(c7);
 }
 
 /// Computation of the MixColumns transformation in the fixsliced representation
@@ -1113,4 +1042,24 @@ fn rotate_rows_1(x: u64) -> u64 {
 #[inline(always)]
 fn rotate_rows_2(x: u64) -> u64 {
     ror(x, ror_distance(2, 0))
+}
+
+#[inline(always)]
+fn rotate_rows_and_columns_1_1(x: u64) -> u64 {
+    rotate_rows_1(rotate_columns_1(x))
+}
+
+#[inline(always)]
+fn rotate_rows_and_columns_1_2(x: u64) -> u64 {
+    rotate_rows_1(rotate_columns_2(x))
+}
+
+#[inline(always)]
+fn rotate_rows_and_columns_1_3(x: u64) -> u64 {
+    rotate_rows_1(rotate_columns_3(x))
+}
+
+#[inline(always)]
+fn rotate_rows_and_columns_2_2(x: u64) -> u64 {
+    rotate_rows_2(rotate_columns_2(x))
 }

--- a/aes/aes-soft/src/fixslice64.rs
+++ b/aes/aes-soft/src/fixslice64.rs
@@ -611,14 +611,14 @@ fn mixcolumns_0(state: &mut State) {
         state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
     );
     let (b0, b1, b2, b3, b4, b5, b6, b7) = (
-        rotate_rows_and_columns_1_3(a0),
-        rotate_rows_and_columns_1_3(a1),
-        rotate_rows_and_columns_1_3(a2),
-        rotate_rows_and_columns_1_3(a3),
-        rotate_rows_and_columns_1_3(a4),
-        rotate_rows_and_columns_1_3(a5),
-        rotate_rows_and_columns_1_3(a6),
-        rotate_rows_and_columns_1_3(a7),
+        rotate_rows_and_columns_1_1(a0),
+        rotate_rows_and_columns_1_1(a1),
+        rotate_rows_and_columns_1_1(a2),
+        rotate_rows_and_columns_1_1(a3),
+        rotate_rows_and_columns_1_1(a4),
+        rotate_rows_and_columns_1_1(a5),
+        rotate_rows_and_columns_1_1(a6),
+        rotate_rows_and_columns_1_1(a7),
     );
     let (c0, c1, c2, c3, c4, c5, c6, c7) = (
         a0 ^ b0,
@@ -685,14 +685,14 @@ fn mixcolumns_2(state: &mut State) {
         state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7]
     );
     let (b0, b1, b2, b3, b4, b5, b6, b7) = (
-        rotate_rows_and_columns_1_1(a0),
-        rotate_rows_and_columns_1_1(a1),
-        rotate_rows_and_columns_1_1(a2),
-        rotate_rows_and_columns_1_1(a3),
-        rotate_rows_and_columns_1_1(a4),
-        rotate_rows_and_columns_1_1(a5),
-        rotate_rows_and_columns_1_1(a6),
-        rotate_rows_and_columns_1_1(a7),
+        rotate_rows_and_columns_1_3(a0),
+        rotate_rows_and_columns_1_3(a1),
+        rotate_rows_and_columns_1_3(a2),
+        rotate_rows_and_columns_1_3(a3),
+        rotate_rows_and_columns_1_3(a4),
+        rotate_rows_and_columns_1_3(a5),
+        rotate_rows_and_columns_1_3(a6),
+        rotate_rows_and_columns_1_3(a7),
     );
     let (c0, c1, c2, c3, c4, c5, c6, c7) = (
         a0 ^ b0,
@@ -1019,21 +1019,6 @@ fn ror_distance(rows: u32, cols: u32) -> u32 {
     (rows << 4) + (cols << 2)
 }
 
-#[inline]
-fn rotate_columns_1(x: u64) -> u64 {
-    ((x >> 12) & 0x000f000f000f000f) | ((x & 0x0fff0fff0fff0fff) << 4)
-}
-
-#[inline]
-fn rotate_columns_2(x: u64) -> u64 {
-    ((x >> 8) & 0x00ff00ff00ff00ff) | ((x & 0x00ff00ff00ff00ff) << 8)
-}
-
-#[inline]
-fn rotate_columns_3(x: u64) -> u64 {
-    ((x >> 4) & 0x0fff0fff0fff0fff) | ((x & 0x000f000f000f000f) << 12)
-}
-
 #[inline(always)]
 fn rotate_rows_1(x: u64) -> u64 {
     ror(x, ror_distance(1, 0))
@@ -1045,21 +1030,29 @@ fn rotate_rows_2(x: u64) -> u64 {
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 fn rotate_rows_and_columns_1_1(x: u64) -> u64 {
-    rotate_rows_1(rotate_columns_1(x))
+    (ror(x, ror_distance(1, 1)) & 0x0fff0fff0fff0fff) |
+    (ror(x, ror_distance(0, 1)) & 0xf000f000f000f000)
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 fn rotate_rows_and_columns_1_2(x: u64) -> u64 {
-    rotate_rows_1(rotate_columns_2(x))
+    (ror(x, ror_distance(1, 2)) & 0x00ff00ff00ff00ff) |
+    (ror(x, ror_distance(0, 2)) & 0xff00ff00ff00ff00)
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 fn rotate_rows_and_columns_1_3(x: u64) -> u64 {
-    rotate_rows_1(rotate_columns_3(x))
+    (ror(x, ror_distance(1, 3)) & 0x000f000f000f000f) |
+    (ror(x, ror_distance(0, 3)) & 0xfff0fff0fff0fff0)
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 fn rotate_rows_and_columns_2_2(x: u64) -> u64 {
-    rotate_rows_2(rotate_columns_2(x))
+    (ror(x, ror_distance(2, 2)) & 0x00ff00ff00ff00ff) |
+    (ror(x, ror_distance(1, 2)) & 0xff00ff00ff00ff00)
 }


### PR DESCRIPTION
Not just reformatting! Improved formula for the several MixColumn variants needed by the fixslice AES with fewer operations and less data dependencies.

@aadomn Although I've done these somewhat intuitively, I believe they can be derived (e.g. for the first-round MixColumns) by grouping the initial equations of [Figure 6](https://eprint.iacr.org/2020/1123.pdf) using:

`rot_cols_2(rot_rows_2(x)) ^ rot_cols_1(rot_rows_3(x)) == rot_cols_2(rot_rows_2(x ^ rot_cols_3(rot_rows_1(x))))`

EDIT: Corrected equation.