### PR TITLE
aes-soft: fix comment

### DIFF
--- a/aes/aes-soft/src/fixslice32.rs
+++ b/aes/aes-soft/src/fixslice32.rs
@@ -1,4 +1,4 @@
-//! Fixsliced implementations of AES-128, AES-192 and AES-256 (encryption-only)
+//! Fixsliced implementations of AES-128, AES-192 and AES-256
 //! adapted from the C implementation.
 //!
 //! All implementations are fully bitsliced and do not rely on any

--- a/aes/aes-soft/src/fixslice64.rs
+++ b/aes/aes-soft/src/fixslice64.rs
@@ -1,4 +1,4 @@
-//! Fixsliced implementations of AES-128, AES-192 and AES-256 (encryption-only)
+//! Fixsliced implementations of AES-128, AES-192 and AES-256
 //! adapted from the C implementation.
 //!
 //! All implementations are fully bitsliced and do not rely on any


### PR DESCRIPTION
The fixsliced implementations now support encryption and decryption.