### PR TITLE
aes-soft v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cipher",
  "opaque-debug",

--- a/aes/aes-soft/CHANGELOG.md
+++ b/aes/aes-soft/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.2 (2020-10-28)
+### Added
+- 64-bit fixsliced AES implementation ([#180])
+
+### Changed
+- Fixsliced AES decryption ([#185])
+- Improved AES fixsliced MixColumns algorithms ([#184])
+
+[#185]: https://github.com/RustCrypto/block-ciphers/pull/185
+[#184]: https://github.com/RustCrypto/block-ciphers/pull/184
+[#180]: https://github.com/RustCrypto/block-ciphers/pull/180
+
 ## 0.6.1 (2020-10-26)
 ### Changed
 - Use fixslicing for AES encryption - 3X performance boost ([#174], [#176], [#177])

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-soft"
-version = "0.6.1"
+version = "0.6.2"
 description = "AES (Rijndael) block ciphers bit-sliced implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- 64-bit fixsliced AES implementation ([#180])

### Changed
- Fixsliced AES decryption ([#185])
- Improved AES fixsliced MixColumns algorithms ([#184])

[#185]: https://github.com/RustCrypto/block-ciphers/pull/185
[#184]: https://github.com/RustCrypto/block-ciphers/pull/184
[#180]: https://github.com/RustCrypto/block-ciphers/pull/180