### PR TITLE
aes-soft: forbid unsafe

### DIFF
--- a/aes/aes-soft/src/lib.rs
+++ b/aes/aes-soft/src/lib.rs
@@ -42,7 +42,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(not(target_pointer_width = "64"))]


### PR DESCRIPTION
We don't have to retain this in perpetuity, but now that the implementation is fully safe code, adding this attribute gets a 🔒 in [cargo-geiger](https://github.com/rust-secure-code/cargo-geiger):

<img width="575" alt="Screen Shot 2020-10-28 at 8 58 42 AM" src="https://user-images.githubusercontent.com/797/97462334-d2f40f00-18fb-11eb-89de-cb9c26e1fd4e.png">
