### PR TITLE
aes-soft v0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "cipher",
  "opaque-debug",

--- a/aes/aes-soft/CHANGELOG.md
+++ b/aes/aes-soft/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.3 (2020-11-01)
+### Changed
+- Comprehensive refactoring of fixslice code ([#192])
+- Forbid `unsafe` ([#190])
+- Re-order (`inv`)`_sbox` using custom scheduler ([#189])
+
+[#192]: https://github.com/RustCrypto/block-ciphers/pull/192
+[#190]: https://github.com/RustCrypto/block-ciphers/pull/190
+[#189]: https://github.com/RustCrypto/block-ciphers/pull/189
+
 ## 0.6.2 (2020-10-28)
 ### Added
 - 64-bit fixsliced AES implementation ([#180])

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-soft"
-version = "0.6.2"
+version = "0.6.3"
 description = "AES (Rijndael) block ciphers bit-sliced implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Comprehensive refactoring of fixslice code ([#192])
- Forbid `unsafe` ([#190])
- Re-order (`inv`)`_sbox` using custom scheduler ([#189])

[#192]: https://github.com/RustCrypto/block-ciphers/pull/192
[#190]: https://github.com/RustCrypto/block-ciphers/pull/190
[#189]: https://github.com/RustCrypto/block-ciphers/pull/189