### PR TITLE
Implement alternative semi-fixslice

### DIFF
--- a/.github/workflows/aes-soft.yml
+++ b/.github/workflows/aes-soft.yml
@@ -66,6 +66,7 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
       - run: cargo test --release --target ${{ matrix.target }}
+      - run: cargo test --release --target ${{ matrix.target }} --features semi_fixslice
 
   # Cross-compiled tests
   cross:
@@ -96,3 +97,4 @@ jobs:
           override: true
       - run: cargo install cross
       - run: cross test --release --target ${{ matrix.target }}
+      - run: cross test --release --target ${{ matrix.target }} --features semi_fixslice

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -16,3 +16,6 @@ opaque-debug = "0.3"
 
 [dev-dependencies]
 cipher = { version = "0.2", features = ["dev"] }
+
+[features]
+semi_fixslice = []

--- a/aes/aes-soft/src/fixslice32.rs
+++ b/aes/aes-soft/src/fixslice32.rs
@@ -62,12 +62,21 @@ pub(crate) fn aes128_key_schedule(key: &GenericArray<u8, U16>) -> FixsliceKeys12
     }
 
     // Adjust to match fixslicing format
-    for i in (8..72).step_by(32) {
-        inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
-        inv_shift_rows_2(&mut rkeys[(i + 8)..(i + 16)]);
-        inv_shift_rows_3(&mut rkeys[(i + 16)..(i + 24)]);
+    #[cfg(feature = "semi_fixslice")]
+    {
+        for i in (8..88).step_by(16) {
+            inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
+        }
     }
-    inv_shift_rows_1(&mut rkeys[72..80]);
+    #[cfg(not(feature = "semi_fixslice"))]
+    {
+        for i in (8..72).step_by(32) {
+            inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
+            inv_shift_rows_2(&mut rkeys[(i + 8)..(i + 16)]);
+            inv_shift_rows_3(&mut rkeys[(i + 16)..(i + 24)]);
+        }
+        inv_shift_rows_1(&mut rkeys[72..80]);
+    }
 
     // Account for NOTs removed from sub_bytes
     for i in 1..11 {
@@ -151,10 +160,19 @@ pub(crate) fn aes192_key_schedule(key: &GenericArray<u8, U24>) -> FixsliceKeys19
     }
 
     // Adjust to match fixslicing format
-    for i in (0..96).step_by(32) {
-        inv_shift_rows_1(&mut rkeys[(i + 8)..(i + 16)]);
-        inv_shift_rows_2(&mut rkeys[(i + 16)..(i + 24)]);
-        inv_shift_rows_3(&mut rkeys[(i + 24)..(i + 32)]);
+    #[cfg(feature = "semi_fixslice")]
+    {
+        for i in (8..104).step_by(16) {
+            inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
+        }
+    }
+    #[cfg(not(feature = "semi_fixslice"))]
+    {
+        for i in (0..96).step_by(32) {
+            inv_shift_rows_1(&mut rkeys[(i + 8)..(i + 16)]);
+            inv_shift_rows_2(&mut rkeys[(i + 16)..(i + 24)]);
+            inv_shift_rows_3(&mut rkeys[(i + 24)..(i + 32)]);
+        }
     }
 
     // Account for NOTs removed from sub_bytes
@@ -197,12 +215,21 @@ pub(crate) fn aes256_key_schedule(key: &GenericArray<u8, U32>) -> FixsliceKeys25
     }
 
     // Adjust to match fixslicing format
-    for i in (8..104).step_by(32) {
-        inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
-        inv_shift_rows_2(&mut rkeys[(i + 8)..(i + 16)]);
-        inv_shift_rows_3(&mut rkeys[(i + 16)..(i + 24)]);
+    #[cfg(feature = "semi_fixslice")]
+    {
+        for i in (8..120).step_by(16) {
+            inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
+        }
     }
-    inv_shift_rows_1(&mut rkeys[104..112]);
+    #[cfg(not(feature = "semi_fixslice"))]
+    {
+        for i in (8..104).step_by(32) {
+            inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
+            inv_shift_rows_2(&mut rkeys[(i + 8)..(i + 16)]);
+            inv_shift_rows_3(&mut rkeys[(i + 16)..(i + 24)]);
+        }
+        inv_shift_rows_1(&mut rkeys[104..112]);
+    }
 
     // Account for NOTs removed from sub_bytes
     for i in 1..15 {
@@ -222,12 +249,20 @@ pub(crate) fn aes128_decrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
     bitslice(&mut state, &blocks[0], &blocks[1]);
 
     add_round_key(&mut state, &rkeys[80..]);
-    // Synchronize fixslice format
-    inv_shift_rows_2(&mut state);
     inv_sub_bytes(&mut state);
+
+    #[cfg(not(feature = "semi_fixslice"))]
+    {
+        inv_shift_rows_2(&mut state);
+    }
 
     let mut rk_off = 72;
     loop {
+        #[cfg(feature = "semi_fixslice")]
+        {
+            inv_shift_rows_2(&mut state);
+        }
+
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         inv_mix_columns_1(&mut state);
         inv_sub_bytes(&mut state);
@@ -242,15 +277,18 @@ pub(crate) fn aes128_decrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
         inv_sub_bytes(&mut state);
         rk_off -= 8;
 
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        inv_mix_columns_3(&mut state);
-        inv_sub_bytes(&mut state);
-        rk_off -= 8;
+        #[cfg(not(feature = "semi_fixslice"))]
+        {
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            inv_mix_columns_3(&mut state);
+            inv_sub_bytes(&mut state);
+            rk_off -= 8;
 
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        inv_mix_columns_2(&mut state);
-        inv_sub_bytes(&mut state);
-        rk_off -= 8;
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            inv_mix_columns_2(&mut state);
+            inv_sub_bytes(&mut state);
+            rk_off -= 8;
+        }
     }
 
     add_round_key(&mut state, &rkeys[..8]);
@@ -276,19 +314,27 @@ pub(crate) fn aes128_encrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         rk_off += 8;
 
+        #[cfg(feature = "semi_fixslice")]
+        {
+            shift_rows_2(&mut state);
+        }
+
         if rk_off == 80 {
             break;
         }
 
-        sub_bytes(&mut state);
-        mix_columns_2(&mut state);
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        rk_off += 8;
+        #[cfg(not(feature = "semi_fixslice"))]
+        {
+            sub_bytes(&mut state);
+            mix_columns_2(&mut state);
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            rk_off += 8;
 
-        sub_bytes(&mut state);
-        mix_columns_3(&mut state);
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        rk_off += 8;
+            sub_bytes(&mut state);
+            mix_columns_3(&mut state);
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            rk_off += 8;
+        }
 
         sub_bytes(&mut state);
         mix_columns_0(&mut state);
@@ -296,9 +342,12 @@ pub(crate) fn aes128_encrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
         rk_off += 8;
     }
 
+    #[cfg(not(feature = "semi_fixslice"))]
+    {
+        shift_rows_2(&mut state);
+    }
+
     sub_bytes(&mut state);
-    // Synchronize fixslice format
-    shift_rows_2(&mut state);
     add_round_key(&mut state, &rkeys[80..]);
 
     inv_bitslice(&mut state, blocks);
@@ -314,20 +363,26 @@ pub(crate) fn aes192_decrypt(rkeys: &FixsliceKeys192, blocks: &mut [Block]) {
     bitslice(&mut state, &blocks[0], &blocks[1]);
 
     add_round_key(&mut state, &rkeys[96..]);
-    // No fixslice synchronization needed
     inv_sub_bytes(&mut state);
 
     let mut rk_off = 88;
     loop {
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        inv_mix_columns_3(&mut state);
-        inv_sub_bytes(&mut state);
-        rk_off -= 8;
+        #[cfg(feature = "semi_fixslice")]
+        {
+            inv_shift_rows_2(&mut state);
+        }
+        #[cfg(not(feature = "semi_fixslice"))]
+        {
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            inv_mix_columns_3(&mut state);
+            inv_sub_bytes(&mut state);
+            rk_off -= 8;
 
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        inv_mix_columns_2(&mut state);
-        inv_sub_bytes(&mut state);
-        rk_off -= 8;
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            inv_mix_columns_2(&mut state);
+            inv_sub_bytes(&mut state);
+            rk_off -= 8;
+        }
 
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         inv_mix_columns_1(&mut state);
@@ -367,15 +422,22 @@ pub(crate) fn aes192_encrypt(rkeys: &FixsliceKeys192, blocks: &mut [Block]) {
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         rk_off += 8;
 
-        sub_bytes(&mut state);
-        mix_columns_2(&mut state);
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        rk_off += 8;
+        #[cfg(feature = "semi_fixslice")]
+        {
+            shift_rows_2(&mut state);
+        }
+        #[cfg(not(feature = "semi_fixslice"))]
+        {
+            sub_bytes(&mut state);
+            mix_columns_2(&mut state);
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            rk_off += 8;
 
-        sub_bytes(&mut state);
-        mix_columns_3(&mut state);
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        rk_off += 8;
+            sub_bytes(&mut state);
+            mix_columns_3(&mut state);
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            rk_off += 8;
+        }
 
         if rk_off == 96 {
             break;
@@ -388,7 +450,6 @@ pub(crate) fn aes192_encrypt(rkeys: &FixsliceKeys192, blocks: &mut [Block]) {
     }
 
     sub_bytes(&mut state);
-    // No fixslice synchronization needed
     add_round_key(&mut state, &rkeys[96..]);
 
     inv_bitslice(&mut state, blocks);
@@ -404,12 +465,20 @@ pub(crate) fn aes256_decrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
     bitslice(&mut state, &blocks[0], &blocks[1]);
 
     add_round_key(&mut state, &rkeys[112..]);
-    // Synchronize fixslice format
-    inv_shift_rows_2(&mut state);
     inv_sub_bytes(&mut state);
+
+    #[cfg(not(feature = "semi_fixslice"))]
+    {
+        inv_shift_rows_2(&mut state);
+    }
 
     let mut rk_off = 104;
     loop {
+        #[cfg(feature = "semi_fixslice")]
+        {
+            inv_shift_rows_2(&mut state);
+        }
+
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         inv_mix_columns_1(&mut state);
         inv_sub_bytes(&mut state);
@@ -424,15 +493,18 @@ pub(crate) fn aes256_decrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
         inv_sub_bytes(&mut state);
         rk_off -= 8;
 
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        inv_mix_columns_3(&mut state);
-        inv_sub_bytes(&mut state);
-        rk_off -= 8;
+        #[cfg(not(feature = "semi_fixslice"))]
+        {
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            inv_mix_columns_3(&mut state);
+            inv_sub_bytes(&mut state);
+            rk_off -= 8;
 
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        inv_mix_columns_2(&mut state);
-        inv_sub_bytes(&mut state);
-        rk_off -= 8;
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            inv_mix_columns_2(&mut state);
+            inv_sub_bytes(&mut state);
+            rk_off -= 8;
+        }
     }
 
     add_round_key(&mut state, &rkeys[..8]);
@@ -458,19 +530,27 @@ pub(crate) fn aes256_encrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         rk_off += 8;
 
+        #[cfg(feature = "semi_fixslice")]
+        {
+            shift_rows_2(&mut state);
+        }
+
         if rk_off == 112 {
             break;
         }
 
-        sub_bytes(&mut state);
-        mix_columns_2(&mut state);
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        rk_off += 8;
+        #[cfg(not(feature = "semi_fixslice"))]
+        {
+            sub_bytes(&mut state);
+            mix_columns_2(&mut state);
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            rk_off += 8;
 
-        sub_bytes(&mut state);
-        mix_columns_3(&mut state);
-        add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
-        rk_off += 8;
+            sub_bytes(&mut state);
+            mix_columns_3(&mut state);
+            add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
+            rk_off += 8;
+        }
 
         sub_bytes(&mut state);
         mix_columns_0(&mut state);
@@ -478,9 +558,12 @@ pub(crate) fn aes256_encrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
         rk_off += 8;
     }
 
+    #[cfg(not(feature = "semi_fixslice"))]
+    {
+        shift_rows_2(&mut state);
+    }
+
     sub_bytes(&mut state);
-    // Synchronize fixslice format
-    shift_rows_2(&mut state);
     add_round_key(&mut state, &rkeys[112..]);
 
     inv_bitslice(&mut state, blocks);
@@ -995,6 +1078,7 @@ define_mix_columns!(
     rotate_rows_and_columns_2_2
 );
 
+#[cfg(not(feature = "semi_fixslice"))]
 define_mix_columns!(
     mix_columns_2,
     inv_mix_columns_2,
@@ -1002,6 +1086,7 @@ define_mix_columns!(
     rotate_rows_2
 );
 
+#[cfg(not(feature = "semi_fixslice"))]
 define_mix_columns!(
     mix_columns_3,
     inv_mix_columns_3,
@@ -1023,6 +1108,7 @@ fn delta_swap_2(a: &mut u32, b: &mut u32, shift: u32, mask: u32) {
 }
 
 /// Applies ShiftRows once on an AES state (or key).
+#[cfg(not(feature = "semi_fixslice"))]
 #[inline]
 fn shift_rows_1(state: &mut [u32]) {
     debug_assert_eq!(state.len(), 8);
@@ -1061,6 +1147,7 @@ fn inv_shift_rows_2(state: &mut [u32]) {
     shift_rows_2(state);
 }
 
+#[cfg(not(feature = "semi_fixslice"))]
 #[inline(always)]
 fn inv_shift_rows_3(state: &mut [u32]) {
     shift_rows_1(state);
@@ -1266,6 +1353,7 @@ fn rotate_rows_and_columns_1_1(x: u32) -> u32 {
     (ror(x, ror_distance(0, 1)) & 0xc0c0c0c0)
 }
 
+#[cfg(not(feature = "semi_fixslice"))]
 #[inline(always)]
 #[rustfmt::skip]
 fn rotate_rows_and_columns_1_2(x: u32) -> u32 {
@@ -1273,6 +1361,7 @@ fn rotate_rows_and_columns_1_2(x: u32) -> u32 {
     (ror(x, ror_distance(0, 2)) & 0xf0f0f0f0)
 }
 
+#[cfg(not(feature = "semi_fixslice"))]
 #[inline(always)]
 #[rustfmt::skip]
 fn rotate_rows_and_columns_1_3(x: u32) -> u32 {


### PR DESCRIPTION
- under cfg feature 'semi_fixslice'
- reduces code size at small cost to performance

Alternative, slightly simpler variant described in [the paper](https://eprint.iacr.org/2020/1123). I'm not sure if this is the ideal way to present the alternative, but it gets working code in place.