### PR TITLE
aes-soft v0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "cipher",
  "opaque-debug",

--- a/aes/aes-soft/CHANGELOG.md
+++ b/aes/aes-soft/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.4 (2020-11-16)
+### Changed
+- Rework of xor_columns ([#197])
+- Implement semi-fixsliced support under `semi_fixslice` Cargo feature ([#195])
+
+[#197]: https://github.com/RustCrypto/block-ciphers/pull/197
+[#195]: https://github.com/RustCrypto/block-ciphers/pull/195
+
 ## 0.6.3 (2020-11-01)
 ### Changed
 - Comprehensive refactoring of fixslice code ([#192])

--- a/aes/aes-soft/Cargo.toml
+++ b/aes/aes-soft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-soft"
-version = "0.6.3"
+version = "0.6.4"
 description = "AES (Rijndael) block ciphers bit-sliced implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Rework of xor_columns ([#197])
- Implement semi-fixsliced support under `semi_fixslice` Cargo feature ([#195])

[#197]: https://github.com/RustCrypto/block-ciphers/pull/197
[#195]: https://github.com/RustCrypto/block-ciphers/pull/195