### PR TITLE
aes: rename `semi_fixslice` feature to `compact`

### DIFF
--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -67,7 +67,7 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
       - run: cargo test --release --target ${{ matrix.target }}
-      - run: cargo test --release --target ${{ matrix.target }} --features semi_fixslice
+      - run: cargo test --release --target ${{ matrix.target }} --features compact
 
   # Tests for the AES-NI backend
   aesni:
@@ -133,4 +133,4 @@ jobs:
           override: true
       - run: cargo install cross
       - run: cross test --release --target ${{ matrix.target }}
-      - run: cross test --release --target ${{ matrix.target }} --features semi_fixslice
+      - run: cross test --release --target ${{ matrix.target }} --features compact

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -24,7 +24,7 @@ opaque-debug = "0.3"
 cipher = { version = "=0.3.0-pre", features = ["dev"] }
 
 [features]
-semi_fixslice = []
+compact = [] # Reduce code size at the cost of performance
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -3,7 +3,11 @@
 //!
 //! It provides two different backends based on what target features
 //! are specified:
+//!
 //! - "soft" portable constant-time implementation based on [fixslicing].
+//!   Enabling the `compact` Cargo feature will reduce the code size of this
+//!   backend at the cost of decreased performance (using a modified form of
+//!   the fixslicing technique called "semi-fixslicing").
 //! - [AES-NI] accelerated implementation for `i686`/`x86_64` target
 //!   architectures with `target-feature=+aes`, as well as an accelerated
 //!   AES-CTR implementation with `target-feature=+aes,+ssse3`

--- a/aes/src/soft/fixslice32.rs
+++ b/aes/src/soft/fixslice32.rs
@@ -62,13 +62,13 @@ pub(crate) fn aes128_key_schedule(key: &GenericArray<u8, U16>) -> FixsliceKeys12
     }
 
     // Adjust to match fixslicing format
-    #[cfg(feature = "semi_fixslice")]
+    #[cfg(feature = "compact")]
     {
         for i in (8..88).step_by(16) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
         }
     }
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         for i in (8..72).step_by(32) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
@@ -157,13 +157,13 @@ pub(crate) fn aes192_key_schedule(key: &GenericArray<u8, U24>) -> FixsliceKeys19
     }
 
     // Adjust to match fixslicing format
-    #[cfg(feature = "semi_fixslice")]
+    #[cfg(feature = "compact")]
     {
         for i in (8..104).step_by(16) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
         }
     }
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         for i in (0..96).step_by(32) {
             inv_shift_rows_1(&mut rkeys[(i + 8)..(i + 16)]);
@@ -215,13 +215,13 @@ pub(crate) fn aes256_key_schedule(key: &GenericArray<u8, U32>) -> FixsliceKeys25
     }
 
     // Adjust to match fixslicing format
-    #[cfg(feature = "semi_fixslice")]
+    #[cfg(feature = "compact")]
     {
         for i in (8..120).step_by(16) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
         }
     }
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         for i in (8..104).step_by(32) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
@@ -251,14 +251,14 @@ pub(crate) fn aes128_decrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
     add_round_key(&mut state, &rkeys[80..]);
     inv_sub_bytes(&mut state);
 
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         inv_shift_rows_2(&mut state);
     }
 
     let mut rk_off = 72;
     loop {
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             inv_shift_rows_2(&mut state);
         }
@@ -277,7 +277,7 @@ pub(crate) fn aes128_decrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
         inv_sub_bytes(&mut state);
         rk_off -= 8;
 
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
             inv_mix_columns_3(&mut state);
@@ -314,7 +314,7 @@ pub(crate) fn aes128_encrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         rk_off += 8;
 
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             shift_rows_2(&mut state);
         }
@@ -323,7 +323,7 @@ pub(crate) fn aes128_encrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
             break;
         }
 
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             sub_bytes(&mut state);
             mix_columns_2(&mut state);
@@ -342,7 +342,7 @@ pub(crate) fn aes128_encrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
         rk_off += 8;
     }
 
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         shift_rows_2(&mut state);
     }
@@ -367,11 +367,11 @@ pub(crate) fn aes192_decrypt(rkeys: &FixsliceKeys192, blocks: &mut [Block]) {
 
     let mut rk_off = 88;
     loop {
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             inv_shift_rows_2(&mut state);
         }
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
             inv_mix_columns_3(&mut state);
@@ -422,11 +422,11 @@ pub(crate) fn aes192_encrypt(rkeys: &FixsliceKeys192, blocks: &mut [Block]) {
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         rk_off += 8;
 
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             shift_rows_2(&mut state);
         }
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             sub_bytes(&mut state);
             mix_columns_2(&mut state);
@@ -467,14 +467,14 @@ pub(crate) fn aes256_decrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
     add_round_key(&mut state, &rkeys[112..]);
     inv_sub_bytes(&mut state);
 
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         inv_shift_rows_2(&mut state);
     }
 
     let mut rk_off = 104;
     loop {
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             inv_shift_rows_2(&mut state);
         }
@@ -493,7 +493,7 @@ pub(crate) fn aes256_decrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
         inv_sub_bytes(&mut state);
         rk_off -= 8;
 
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
             inv_mix_columns_3(&mut state);
@@ -530,7 +530,7 @@ pub(crate) fn aes256_encrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         rk_off += 8;
 
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             shift_rows_2(&mut state);
         }
@@ -539,7 +539,7 @@ pub(crate) fn aes256_encrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
             break;
         }
 
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             sub_bytes(&mut state);
             mix_columns_2(&mut state);
@@ -558,7 +558,7 @@ pub(crate) fn aes256_encrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
         rk_off += 8;
     }
 
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         shift_rows_2(&mut state);
     }
@@ -1078,7 +1078,7 @@ define_mix_columns!(
     rotate_rows_and_columns_2_2
 );
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 define_mix_columns!(
     mix_columns_2,
     inv_mix_columns_2,
@@ -1086,7 +1086,7 @@ define_mix_columns!(
     rotate_rows_2
 );
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 define_mix_columns!(
     mix_columns_3,
     inv_mix_columns_3,
@@ -1108,7 +1108,7 @@ fn delta_swap_2(a: &mut u32, b: &mut u32, shift: u32, mask: u32) {
 }
 
 /// Applies ShiftRows once on an AES state (or key).
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 #[inline]
 fn shift_rows_1(state: &mut [u32]) {
     debug_assert_eq!(state.len(), 8);
@@ -1147,7 +1147,7 @@ fn inv_shift_rows_2(state: &mut [u32]) {
     shift_rows_2(state);
 }
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 #[inline(always)]
 fn inv_shift_rows_3(state: &mut [u32]) {
     shift_rows_1(state);
@@ -1348,7 +1348,7 @@ fn rotate_rows_and_columns_1_1(x: u32) -> u32 {
     (ror(x, ror_distance(0, 1)) & 0xc0c0c0c0)
 }
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 #[inline(always)]
 #[rustfmt::skip]
 fn rotate_rows_and_columns_1_2(x: u32) -> u32 {
@@ -1356,7 +1356,7 @@ fn rotate_rows_and_columns_1_2(x: u32) -> u32 {
     (ror(x, ror_distance(0, 2)) & 0xf0f0f0f0)
 }
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 #[inline(always)]
 #[rustfmt::skip]
 fn rotate_rows_and_columns_1_3(x: u32) -> u32 {

--- a/aes/src/soft/fixslice64.rs
+++ b/aes/src/soft/fixslice64.rs
@@ -61,13 +61,13 @@ pub(crate) fn aes128_key_schedule(key: &GenericArray<u8, U16>) -> FixsliceKeys12
     }
 
     // Adjust to match fixslicing format
-    #[cfg(feature = "semi_fixslice")]
+    #[cfg(feature = "compact")]
     {
         for i in (8..88).step_by(16) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
         }
     }
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         for i in (8..72).step_by(32) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
@@ -167,13 +167,13 @@ pub(crate) fn aes192_key_schedule(key: &GenericArray<u8, U24>) -> FixsliceKeys19
     }
 
     // Adjust to match fixslicing format
-    #[cfg(feature = "semi_fixslice")]
+    #[cfg(feature = "compact")]
     {
         for i in (8..104).step_by(16) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
         }
     }
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         for i in (0..96).step_by(32) {
             inv_shift_rows_1(&mut rkeys[(i + 8)..(i + 16)]);
@@ -237,13 +237,13 @@ pub(crate) fn aes256_key_schedule(key: &GenericArray<u8, U32>) -> FixsliceKeys25
     }
 
     // Adjust to match fixslicing format
-    #[cfg(feature = "semi_fixslice")]
+    #[cfg(feature = "compact")]
     {
         for i in (8..120).step_by(16) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
         }
     }
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         for i in (8..104).step_by(32) {
             inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
@@ -273,14 +273,14 @@ pub(crate) fn aes128_decrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
     add_round_key(&mut state, &rkeys[80..]);
     inv_sub_bytes(&mut state);
 
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         inv_shift_rows_2(&mut state);
     }
 
     let mut rk_off = 72;
     loop {
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             inv_shift_rows_2(&mut state);
         }
@@ -299,7 +299,7 @@ pub(crate) fn aes128_decrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
         inv_sub_bytes(&mut state);
         rk_off -= 8;
 
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
             inv_mix_columns_3(&mut state);
@@ -336,7 +336,7 @@ pub(crate) fn aes128_encrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         rk_off += 8;
 
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             shift_rows_2(&mut state);
         }
@@ -345,7 +345,7 @@ pub(crate) fn aes128_encrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
             break;
         }
 
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             sub_bytes(&mut state);
             mix_columns_2(&mut state);
@@ -364,7 +364,7 @@ pub(crate) fn aes128_encrypt(rkeys: &FixsliceKeys128, blocks: &mut [Block]) {
         rk_off += 8;
     }
 
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         shift_rows_2(&mut state);
     }
@@ -389,11 +389,11 @@ pub(crate) fn aes192_decrypt(rkeys: &FixsliceKeys192, blocks: &mut [Block]) {
 
     let mut rk_off = 88;
     loop {
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             inv_shift_rows_2(&mut state);
         }
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
             inv_mix_columns_3(&mut state);
@@ -444,11 +444,11 @@ pub(crate) fn aes192_encrypt(rkeys: &FixsliceKeys192, blocks: &mut [Block]) {
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         rk_off += 8;
 
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             shift_rows_2(&mut state);
         }
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             sub_bytes(&mut state);
             mix_columns_2(&mut state);
@@ -489,14 +489,14 @@ pub(crate) fn aes256_decrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
     add_round_key(&mut state, &rkeys[112..]);
     inv_sub_bytes(&mut state);
 
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         inv_shift_rows_2(&mut state);
     }
 
     let mut rk_off = 104;
     loop {
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             inv_shift_rows_2(&mut state);
         }
@@ -515,7 +515,7 @@ pub(crate) fn aes256_decrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
         inv_sub_bytes(&mut state);
         rk_off -= 8;
 
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
             inv_mix_columns_3(&mut state);
@@ -552,7 +552,7 @@ pub(crate) fn aes256_encrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
         add_round_key(&mut state, &rkeys[rk_off..(rk_off + 8)]);
         rk_off += 8;
 
-        #[cfg(feature = "semi_fixslice")]
+        #[cfg(feature = "compact")]
         {
             shift_rows_2(&mut state);
         }
@@ -561,7 +561,7 @@ pub(crate) fn aes256_encrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
             break;
         }
 
-        #[cfg(not(feature = "semi_fixslice"))]
+        #[cfg(not(feature = "compact"))]
         {
             sub_bytes(&mut state);
             mix_columns_2(&mut state);
@@ -580,7 +580,7 @@ pub(crate) fn aes256_encrypt(rkeys: &FixsliceKeys256, blocks: &mut [Block]) {
         rk_off += 8;
     }
 
-    #[cfg(not(feature = "semi_fixslice"))]
+    #[cfg(not(feature = "compact"))]
     {
         shift_rows_2(&mut state);
     }
@@ -1100,7 +1100,7 @@ define_mix_columns!(
     rotate_rows_and_columns_2_2
 );
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 define_mix_columns!(
     mix_columns_2,
     inv_mix_columns_2,
@@ -1108,7 +1108,7 @@ define_mix_columns!(
     rotate_rows_2
 );
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 define_mix_columns!(
     mix_columns_3,
     inv_mix_columns_3,
@@ -1130,7 +1130,7 @@ fn delta_swap_2(a: &mut u64, b: &mut u64, shift: u32, mask: u64) {
 }
 
 /// Applies ShiftRows once on an AES state (or key).
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 #[inline]
 fn shift_rows_1(state: &mut [u64]) {
     debug_assert_eq!(state.len(), 8);
@@ -1169,7 +1169,7 @@ fn inv_shift_rows_2(state: &mut [u64]) {
     shift_rows_2(state);
 }
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 #[inline(always)]
 fn inv_shift_rows_3(state: &mut [u64]) {
     shift_rows_1(state);
@@ -1402,7 +1402,7 @@ fn rotate_rows_and_columns_1_1(x: u64) -> u64 {
     (ror(x, ror_distance(0, 1)) & 0xf000f000f000f000)
 }
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 #[inline(always)]
 #[rustfmt::skip]
 fn rotate_rows_and_columns_1_2(x: u64) -> u64 {
@@ -1410,7 +1410,7 @@ fn rotate_rows_and_columns_1_2(x: u64) -> u64 {
     (ror(x, ror_distance(0, 2)) & 0xff00ff00ff00ff00)
 }
 
-#[cfg(not(feature = "semi_fixslice"))]
+#[cfg(not(feature = "compact"))]
 #[inline(always)]
 #[rustfmt::skip]
 fn rotate_rows_and_columns_1_3(x: u64) -> u64 {


### PR DESCRIPTION
The "semi_fixslice" name is jargon and doesn't describe what the feature does, which is reduce code size.

This commit renames it to describe what the feature does: make code "compact".