### PR TITLE
aes: remove Copy from public types of "soft" impls

### DIFF
--- a/aes/src/soft/impls.rs
+++ b/aes/src/soft/impls.rs
@@ -20,7 +20,11 @@ macro_rules! define_aes_impl {
         $doc:expr
     ) => {
         #[doc=$doc]
-        #[derive(Copy, Clone)]
+        #[derive(Clone)]
+        #[cfg_attr(
+            all(any(target_arch = "x86_64", target_arch = "x86"), not(feature = "force-soft")),
+            derive(Copy)
+        )] // TODO(tarcieri): remove this when `ManuallyDrop` is stable
         pub struct $name {
             keys: $fixslice_keys,
         }


### PR DESCRIPTION
When using the `autodetect` module, we store the possible backing AES implementations in a `union`, which presently requires all fields be `Copy` until `ManuallyDrop` stabilizes in Rust 1.49.

However, the "soft" types are directly exposed on non-x86 architectures or when the `force-soft` feature is enabled. Having these types be `Copy` when the autodetect wrappers aren't is inconsistent, and it's better to require an explicit clone for these to make users think when they make copies of key material.

As a workaround until `ManuallyDrop` lands, this gates the `Copy` impl on the "soft" types to only cases where it is hidden behind the autodetect facade (i.e. when they presently *need* to be `Copy`).