### PR TITLE
aes: make autodetect unions non-Copy; MSRV 1.49+

### DIFF
--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -58,7 +58,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -89,7 +89,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -97,7 +97,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -123,13 +123,13 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/aes/README.md
+++ b/aes/README.md
@@ -42,7 +42,7 @@ using a portable implementation based on bitslicing.
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.49** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -74,7 +74,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aes/badge.svg
 [docs-link]: https://docs.rs/aes/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/aes/src/ni/aes128.rs
+++ b/aes/src/ni/aes128.rs
@@ -12,7 +12,7 @@ mod expand;
 mod test_expand;
 
 /// AES-128 block cipher
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Aes128 {
     encrypt_keys: [__m128i; 11],
     decrypt_keys: [__m128i; 11],

--- a/aes/src/ni/aes192.rs
+++ b/aes/src/ni/aes192.rs
@@ -12,7 +12,7 @@ mod expand;
 mod test_expand;
 
 /// AES-192 block cipher
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Aes192 {
     encrypt_keys: [__m128i; 13],
     decrypt_keys: [__m128i; 13],

--- a/aes/src/ni/aes256.rs
+++ b/aes/src/ni/aes256.rs
@@ -12,7 +12,7 @@ mod expand;
 mod test_expand;
 
 /// AES-256 block cipher
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Aes256 {
     encrypt_keys: [__m128i; 15],
     decrypt_keys: [__m128i; 15],

--- a/aes/src/soft/impls.rs
+++ b/aes/src/soft/impls.rs
@@ -21,10 +21,6 @@ macro_rules! define_aes_impl {
     ) => {
         #[doc=$doc]
         #[derive(Clone)]
-        #[cfg_attr(
-            all(any(target_arch = "x86_64", target_arch = "x86"), not(feature = "force-soft")),
-            derive(Copy)
-        )] // TODO(tarcieri): remove this when `ManuallyDrop` is stable
         pub struct $name {
             keys: $fixslice_keys,
         }


### PR DESCRIPTION
Uses the new `core::mem::ManuallyDrop` feature to allow the inner types of unions to be non-`Copy`.