### PR TITLE
block-modes: bump MSRV to 1.49+

### DIFF
--- a/.github/workflows/block-modes.yml
+++ b/.github/workflows/block-modes.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -31,24 +31,26 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+          profile: minimal
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check
     - run: cargo test
     - run: cargo test --all-features

--- a/.github/workflows/blowfish.yml
+++ b/.github/workflows/blowfish.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/cast5.yml
+++ b/.github/workflows/cast5.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/des.yml
+++ b/.github/workflows/des.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/gost-modes.yml
+++ b/.github/workflows/gost-modes.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,7 +48,8 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo test -- no-default-features
     - run: cargo test

--- a/.github/workflows/idea.yml
+++ b/.github/workflows/idea.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/kuznyechik.yml
+++ b/.github/workflows/kuznyechik.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,7 +48,8 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo test
     - run: cargo test --features no_unroll

--- a/.github/workflows/magma.yml
+++ b/.github/workflows/magma.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/rc2.yml
+++ b/.github/workflows/rc2.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/serpent.yml
+++ b/.github/workflows/serpent.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/sm4.yml
+++ b/.github/workflows/sm4.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/threefish.yml
+++ b/.github/workflows/threefish.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/.github/workflows/twofish.yml
+++ b/.github/workflows/twofish.yml
@@ -36,6 +36,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,8 +48,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
     - run: cargo check --all-features
     - run: cargo test --no-default-features
     - run: cargo test

--- a/block-modes/README.md
+++ b/block-modes/README.md
@@ -20,7 +20,7 @@ ciphers) see crates in the [RustCrypto/stream-ciphers][2] repository.
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.49** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -52,7 +52,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/block-modes/badge.svg
 [docs-link]: https://docs.rs/block-modes/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260039-block-ciphers
 [build-image]: https://github.com/RustCrypto/block-ciphers/workflows/block-modes/badge.svg?branch=master&event=push


### PR DESCRIPTION
The tests are failing because the `aes` crate now uses `ManuallyDrop` unions which are MSRV 1.49 (see #216)