### PR TITLE
block-modes: MSRV 1.41

### DIFF
--- a/.github/workflows/block-modes.yml
+++ b/.github/workflows/block-modes.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49.0 # MSRV
+          - 1.41.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49.0 # MSRV
+          - 1.41.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -15,7 +15,7 @@ block-padding = "0.2"
 cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-aes = { version = "=0.7.0-pre", path = "../aes" }
+aes = { version = "=0.7.0-pre", path = "../aes", features = ["force-soft"] }
 hex-literal = "0.2"
 
 [features]

--- a/block-modes/README.md
+++ b/block-modes/README.md
@@ -20,7 +20,7 @@ ciphers) see crates in the [RustCrypto/stream-ciphers][2] repository.
 
 ## Minimum Supported Rust Version
 
-Rust **1.49** or higher.
+Rust **1.41** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -52,7 +52,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/block-modes/badge.svg
 [docs-link]: https://docs.rs/block-modes/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260039-block-ciphers
 [build-image]: https://github.com/RustCrypto/block-ciphers/workflows/block-modes/badge.svg?branch=master&event=push


### PR DESCRIPTION
As @newpavlov pointed out, the actual MSRV of this crate didn't change.

If we run tests with the `aes` crate's `force-soft` feature enabled, we can still CI with Rust 1.41.