### PR TITLE
aes: replace AES-NI macros with inline(always) functions

### DIFF
--- a/aes/src/ni/aes128.rs
+++ b/aes/src/ni/aes128.rs
@@ -1,40 +1,47 @@
-use super::arch::*;
+use super::{
+    arch::*,
+    utils::{
+        aesdec8, aesdeclast8, aesenc8, aesenclast8, load8, store8, xor8, Block128, Block128x8,
+        U128x8,
+    },
+};
 use cipher::{
     consts::{U16, U8},
     generic_array::GenericArray,
     BlockCipher, BlockDecrypt, BlockEncrypt, NewBlockCipher,
 };
 
-use super::utils::{Block128, Block128x8};
-
 mod expand;
 #[cfg(test)]
 mod test_expand;
 
+/// AES-128 round keys
+type RoundKeys = [__m128i; 11];
+
 /// AES-128 block cipher
 #[derive(Clone)]
 pub struct Aes128 {
-    encrypt_keys: [__m128i; 11],
-    decrypt_keys: [__m128i; 11],
+    encrypt_keys: RoundKeys,
+    decrypt_keys: RoundKeys,
 }
 
 impl Aes128 {
     #[inline(always)]
-    pub(crate) fn encrypt8(&self, mut blocks: [__m128i; 8]) -> [__m128i; 8] {
+    pub(crate) fn encrypt8(&self, mut blocks: U128x8) -> U128x8 {
         #[inline]
         #[target_feature(enable = "aes")]
-        unsafe fn aesni128_encrypt8(keys: &[__m128i; 11], blocks: &mut [__m128i; 8]) {
-            xor8!(blocks, keys[0]);
-            aesenc8!(blocks, keys[1]);
-            aesenc8!(blocks, keys[2]);
-            aesenc8!(blocks, keys[3]);
-            aesenc8!(blocks, keys[4]);
-            aesenc8!(blocks, keys[5]);
-            aesenc8!(blocks, keys[6]);
-            aesenc8!(blocks, keys[7]);
-            aesenc8!(blocks, keys[8]);
-            aesenc8!(blocks, keys[9]);
-            aesenclast8!(blocks, keys[10]);
+        unsafe fn aesni128_encrypt8(keys: &RoundKeys, blocks: &mut U128x8) {
+            xor8(blocks, keys[0]);
+            aesenc8(blocks, keys[1]);
+            aesenc8(blocks, keys[2]);
+            aesenc8(blocks, keys[3]);
+            aesenc8(blocks, keys[4]);
+            aesenc8(blocks, keys[5]);
+            aesenc8(blocks, keys[6]);
+            aesenc8(blocks, keys[7]);
+            aesenc8(blocks, keys[8]);
+            aesenc8(blocks, keys[9]);
+            aesenclast8(blocks, keys[10]);
         }
         unsafe { aesni128_encrypt8(&self.encrypt_keys, &mut blocks) };
         blocks
@@ -44,7 +51,7 @@ impl Aes128 {
     pub(crate) fn encrypt(&self, block: __m128i) -> __m128i {
         #[inline]
         #[target_feature(enable = "aes")]
-        unsafe fn aesni128_encrypt1(keys: &[__m128i; 11], mut block: __m128i) -> __m128i {
+        unsafe fn aesni128_encrypt1(keys: &RoundKeys, mut block: __m128i) -> __m128i {
             block = _mm_xor_si128(block, keys[0]);
             block = _mm_aesenc_si128(block, keys[1]);
             block = _mm_aesenc_si128(block, keys[2]);
@@ -96,10 +103,8 @@ impl BlockEncrypt for Aes128 {
 
     #[inline]
     fn encrypt_par_blocks(&self, blocks: &mut Block128x8) {
-        unsafe {
-            let b = self.encrypt8(load8!(blocks));
-            store8!(blocks, b);
-        }
+        let b = self.encrypt8(load8(blocks));
+        store8(blocks, b);
     }
 }
 
@@ -108,7 +113,7 @@ impl BlockDecrypt for Aes128 {
     fn decrypt_block(&self, block: &mut Block128) {
         #[inline]
         #[target_feature(enable = "aes")]
-        unsafe fn aes128_decrypt1(block: &mut Block128, keys: &[__m128i; 11]) {
+        unsafe fn aes128_decrypt1(block: &mut Block128, keys: &RoundKeys) {
             // Safety: `loadu` and `storeu` support unaligned access
             #[allow(clippy::cast_ptr_alignment)]
             let mut b = _mm_loadu_si128(block.as_ptr() as *const __m128i);
@@ -137,20 +142,20 @@ impl BlockDecrypt for Aes128 {
     fn decrypt_par_blocks(&self, blocks: &mut Block128x8) {
         #[inline]
         #[target_feature(enable = "aes")]
-        unsafe fn aes128_decrypt8(blocks: &mut Block128x8, keys: &[__m128i; 11]) {
-            let mut b = load8!(blocks);
-            xor8!(b, keys[10]);
-            aesdec8!(b, keys[9]);
-            aesdec8!(b, keys[8]);
-            aesdec8!(b, keys[7]);
-            aesdec8!(b, keys[6]);
-            aesdec8!(b, keys[5]);
-            aesdec8!(b, keys[4]);
-            aesdec8!(b, keys[3]);
-            aesdec8!(b, keys[2]);
-            aesdec8!(b, keys[1]);
-            aesdeclast8!(b, keys[0]);
-            store8!(blocks, b);
+        unsafe fn aes128_decrypt8(blocks: &mut Block128x8, keys: &RoundKeys) {
+            let mut b = load8(blocks);
+            xor8(&mut b, keys[10]);
+            aesdec8(&mut b, keys[9]);
+            aesdec8(&mut b, keys[8]);
+            aesdec8(&mut b, keys[7]);
+            aesdec8(&mut b, keys[6]);
+            aesdec8(&mut b, keys[5]);
+            aesdec8(&mut b, keys[4]);
+            aesdec8(&mut b, keys[3]);
+            aesdec8(&mut b, keys[2]);
+            aesdec8(&mut b, keys[1]);
+            aesdeclast8(&mut b, keys[0]);
+            store8(blocks, b);
         }
 
         unsafe { aes128_decrypt8(blocks, &self.decrypt_keys) }

--- a/aes/src/ni/aes128/expand.rs
+++ b/aes/src/ni/aes128/expand.rs
@@ -1,3 +1,4 @@
+use super::RoundKeys;
 use crate::ni::arch::*;
 
 use core::mem;
@@ -25,10 +26,10 @@ macro_rules! expand_round {
 }
 
 #[inline(always)]
-pub(super) fn expand(key: &[u8; 16]) -> ([__m128i; 11], [__m128i; 11]) {
+pub(super) fn expand(key: &[u8; 16]) -> (RoundKeys, RoundKeys) {
     unsafe {
-        let mut enc_keys: [__m128i; 11] = mem::zeroed();
-        let mut dec_keys: [__m128i; 11] = mem::zeroed();
+        let mut enc_keys: RoundKeys = mem::zeroed();
+        let mut dec_keys: RoundKeys = mem::zeroed();
 
         // Safety: `loadu` supports unaligned loads
         #[allow(clippy::cast_ptr_alignment)]

--- a/aes/src/ni/aes192.rs
+++ b/aes/src/ni/aes192.rs
@@ -1,42 +1,49 @@
-use super::arch::*;
+use super::{
+    arch::*,
+    utils::{
+        aesdec8, aesdeclast8, aesenc8, aesenclast8, load8, store8, xor8, Block128, Block128x8,
+        U128x8,
+    },
+};
 use cipher::{
     consts::{U16, U24, U8},
     generic_array::GenericArray,
     BlockCipher, BlockDecrypt, BlockEncrypt, NewBlockCipher,
 };
 
-use super::utils::{Block128, Block128x8};
-
 mod expand;
 #[cfg(test)]
 mod test_expand;
 
+/// AES-192 round keys
+type RoundKeys = [__m128i; 13];
+
 /// AES-192 block cipher
 #[derive(Clone)]
 pub struct Aes192 {
-    encrypt_keys: [__m128i; 13],
-    decrypt_keys: [__m128i; 13],
+    encrypt_keys: RoundKeys,
+    decrypt_keys: RoundKeys,
 }
 
 impl Aes192 {
     #[inline(always)]
-    pub(crate) fn encrypt8(&self, mut blocks: [__m128i; 8]) -> [__m128i; 8] {
+    pub(crate) fn encrypt8(&self, mut blocks: U128x8) -> U128x8 {
         #[inline]
         #[target_feature(enable = "aes")]
-        unsafe fn aesni192_encrypt8(keys: &[__m128i; 13], blocks: &mut [__m128i; 8]) {
-            xor8!(blocks, keys[0]);
-            aesenc8!(blocks, keys[1]);
-            aesenc8!(blocks, keys[2]);
-            aesenc8!(blocks, keys[3]);
-            aesenc8!(blocks, keys[4]);
-            aesenc8!(blocks, keys[5]);
-            aesenc8!(blocks, keys[6]);
-            aesenc8!(blocks, keys[7]);
-            aesenc8!(blocks, keys[8]);
-            aesenc8!(blocks, keys[9]);
-            aesenc8!(blocks, keys[10]);
-            aesenc8!(blocks, keys[11]);
-            aesenclast8!(blocks, keys[12]);
+        unsafe fn aesni192_encrypt8(keys: &RoundKeys, blocks: &mut U128x8) {
+            xor8(blocks, keys[0]);
+            aesenc8(blocks, keys[1]);
+            aesenc8(blocks, keys[2]);
+            aesenc8(blocks, keys[3]);
+            aesenc8(blocks, keys[4]);
+            aesenc8(blocks, keys[5]);
+            aesenc8(blocks, keys[6]);
+            aesenc8(blocks, keys[7]);
+            aesenc8(blocks, keys[8]);
+            aesenc8(blocks, keys[9]);
+            aesenc8(blocks, keys[10]);
+            aesenc8(blocks, keys[11]);
+            aesenclast8(blocks, keys[12]);
         }
         unsafe { aesni192_encrypt8(&self.encrypt_keys, &mut blocks) };
         blocks
@@ -46,7 +53,7 @@ impl Aes192 {
     pub(crate) fn encrypt(&self, block: __m128i) -> __m128i {
         #[inline]
         #[target_feature(enable = "aes")]
-        unsafe fn aesni192_encrypt1(keys: &[__m128i; 13], mut block: __m128i) -> __m128i {
+        unsafe fn aesni192_encrypt1(keys: &RoundKeys, mut block: __m128i) -> __m128i {
             block = _mm_xor_si128(block, keys[0]);
             block = _mm_aesenc_si128(block, keys[1]);
             block = _mm_aesenc_si128(block, keys[2]);
@@ -98,10 +105,8 @@ impl BlockEncrypt for Aes192 {
 
     #[inline]
     fn encrypt_par_blocks(&self, blocks: &mut Block128x8) {
-        unsafe {
-            let b = self.encrypt8(load8!(blocks));
-            store8!(blocks, b);
-        }
+        let b = self.encrypt8(load8(blocks));
+        store8(blocks, b);
     }
 }
 
@@ -110,7 +115,7 @@ impl BlockDecrypt for Aes192 {
     fn decrypt_block(&self, block: &mut Block128) {
         #[inline]
         #[target_feature(enable = "aes")]
-        unsafe fn aes192_decrypt1(block: &mut Block128, keys: &[__m128i; 13]) {
+        unsafe fn aes192_decrypt1(block: &mut Block128, keys: &RoundKeys) {
             // Safety: `loadu` and `storeu` support unaligned access
             #[allow(clippy::cast_ptr_alignment)]
             let mut b = _mm_loadu_si128(block.as_ptr() as *const __m128i);
@@ -141,22 +146,22 @@ impl BlockDecrypt for Aes192 {
     fn decrypt_par_blocks(&self, blocks: &mut Block128x8) {
         #[inline]
         #[target_feature(enable = "aes")]
-        unsafe fn aes192_decrypt8(blocks: &mut Block128x8, keys: &[__m128i; 13]) {
-            let mut b = load8!(blocks);
-            xor8!(b, keys[12]);
-            aesdec8!(b, keys[11]);
-            aesdec8!(b, keys[10]);
-            aesdec8!(b, keys[9]);
-            aesdec8!(b, keys[8]);
-            aesdec8!(b, keys[7]);
-            aesdec8!(b, keys[6]);
-            aesdec8!(b, keys[5]);
-            aesdec8!(b, keys[4]);
-            aesdec8!(b, keys[3]);
-            aesdec8!(b, keys[2]);
-            aesdec8!(b, keys[1]);
-            aesdeclast8!(b, keys[0]);
-            store8!(blocks, b);
+        unsafe fn aes192_decrypt8(blocks: &mut Block128x8, keys: &RoundKeys) {
+            let mut b = load8(blocks);
+            xor8(&mut b, keys[12]);
+            aesdec8(&mut b, keys[11]);
+            aesdec8(&mut b, keys[10]);
+            aesdec8(&mut b, keys[9]);
+            aesdec8(&mut b, keys[8]);
+            aesdec8(&mut b, keys[7]);
+            aesdec8(&mut b, keys[6]);
+            aesdec8(&mut b, keys[5]);
+            aesdec8(&mut b, keys[4]);
+            aesdec8(&mut b, keys[3]);
+            aesdec8(&mut b, keys[2]);
+            aesdec8(&mut b, keys[1]);
+            aesdeclast8(&mut b, keys[0]);
+            store8(blocks, b);
         }
 
         unsafe { aes192_decrypt8(blocks, &self.decrypt_keys) }

--- a/aes/src/ni/aes192/expand.rs
+++ b/aes/src/ni/aes192/expand.rs
@@ -1,3 +1,4 @@
+use super::RoundKeys;
 use crate::ni::arch::*;
 
 use core::{mem, ptr};
@@ -34,10 +35,10 @@ macro_rules! shuffle {
 }
 
 #[inline(always)]
-pub(super) fn expand(key: &[u8; 24]) -> ([__m128i; 13], [__m128i; 13]) {
+pub(super) fn expand(key: &[u8; 24]) -> (RoundKeys, RoundKeys) {
     unsafe {
-        let mut enc_keys: [__m128i; 13] = mem::zeroed();
-        let mut dec_keys: [__m128i; 13] = mem::zeroed();
+        let mut enc_keys: RoundKeys = mem::zeroed();
+        let mut dec_keys: RoundKeys = mem::zeroed();
 
         macro_rules! store {
             ($i:expr, $k:expr) => {

--- a/aes/src/ni/aes256/expand.rs
+++ b/aes/src/ni/aes256/expand.rs
@@ -1,3 +1,4 @@
+use super::RoundKeys;
 use crate::ni::arch::*;
 
 use core::mem;
@@ -62,12 +63,12 @@ macro_rules! expand_round_last {
 }
 
 #[inline(always)]
-pub(super) fn expand(key: &[u8; 32]) -> ([__m128i; 15], [__m128i; 15]) {
+pub(super) fn expand(key: &[u8; 32]) -> (RoundKeys, RoundKeys) {
     // Safety: `loadu` and `storeu` support unaligned access
     #[allow(clippy::cast_ptr_alignment)]
     unsafe {
-        let mut enc_keys: [__m128i; 15] = mem::zeroed();
-        let mut dec_keys: [__m128i; 15] = mem::zeroed();
+        let mut enc_keys: RoundKeys = mem::zeroed();
+        let mut dec_keys: RoundKeys = mem::zeroed();
 
         let kp = key.as_ptr() as *const __m128i;
         let k1 = _mm_loadu_si128(kp);

--- a/aes/src/ni/utils.rs
+++ b/aes/src/ni/utils.rs
@@ -1,15 +1,17 @@
-#[cfg(test)]
-use super::arch::__m128i;
-#[cfg(test)]
-use core::mem;
+//! Utility functions
 
+use super::arch::*;
 use cipher::{
     consts::{U16, U8},
     generic_array::GenericArray,
 };
 
+#[cfg(test)]
+use core::mem;
+
 pub type Block128 = GenericArray<u8, U16>;
 pub type Block128x8 = GenericArray<GenericArray<u8, U16>, U8>;
+pub type U128x8 = [__m128i; 8];
 
 #[cfg(test)]
 pub(crate) fn check(a: &[__m128i], b: &[[u64; 2]]) {
@@ -20,95 +22,102 @@ pub(crate) fn check(a: &[__m128i], b: &[[u64; 2]]) {
     }
 }
 
-macro_rules! load8 {
-    ($blocks:expr) => {
+#[inline(always)]
+pub(crate) fn load8(blocks: &Block128x8) -> U128x8 {
+    unsafe {
         [
-            _mm_loadu_si128($blocks[0].as_ptr() as *const __m128i),
-            _mm_loadu_si128($blocks[1].as_ptr() as *const __m128i),
-            _mm_loadu_si128($blocks[2].as_ptr() as *const __m128i),
-            _mm_loadu_si128($blocks[3].as_ptr() as *const __m128i),
-            _mm_loadu_si128($blocks[4].as_ptr() as *const __m128i),
-            _mm_loadu_si128($blocks[5].as_ptr() as *const __m128i),
-            _mm_loadu_si128($blocks[6].as_ptr() as *const __m128i),
-            _mm_loadu_si128($blocks[7].as_ptr() as *const __m128i),
+            _mm_loadu_si128(blocks[0].as_ptr() as *const __m128i),
+            _mm_loadu_si128(blocks[1].as_ptr() as *const __m128i),
+            _mm_loadu_si128(blocks[2].as_ptr() as *const __m128i),
+            _mm_loadu_si128(blocks[3].as_ptr() as *const __m128i),
+            _mm_loadu_si128(blocks[4].as_ptr() as *const __m128i),
+            _mm_loadu_si128(blocks[5].as_ptr() as *const __m128i),
+            _mm_loadu_si128(blocks[6].as_ptr() as *const __m128i),
+            _mm_loadu_si128(blocks[7].as_ptr() as *const __m128i),
         ]
-    };
+    }
 }
 
-macro_rules! store8 {
-    ($blocks:expr, $b:expr) => {
-        _mm_storeu_si128($blocks[0].as_mut_ptr() as *mut __m128i, $b[0]);
-        _mm_storeu_si128($blocks[1].as_mut_ptr() as *mut __m128i, $b[1]);
-        _mm_storeu_si128($blocks[2].as_mut_ptr() as *mut __m128i, $b[2]);
-        _mm_storeu_si128($blocks[3].as_mut_ptr() as *mut __m128i, $b[3]);
-        _mm_storeu_si128($blocks[4].as_mut_ptr() as *mut __m128i, $b[4]);
-        _mm_storeu_si128($blocks[5].as_mut_ptr() as *mut __m128i, $b[5]);
-        _mm_storeu_si128($blocks[6].as_mut_ptr() as *mut __m128i, $b[6]);
-        _mm_storeu_si128($blocks[7].as_mut_ptr() as *mut __m128i, $b[7]);
-    };
+#[inline(always)]
+pub(crate) fn store8(blocks: &mut Block128x8, b: U128x8) {
+    unsafe {
+        _mm_storeu_si128(blocks[0].as_mut_ptr() as *mut __m128i, b[0]);
+        _mm_storeu_si128(blocks[1].as_mut_ptr() as *mut __m128i, b[1]);
+        _mm_storeu_si128(blocks[2].as_mut_ptr() as *mut __m128i, b[2]);
+        _mm_storeu_si128(blocks[3].as_mut_ptr() as *mut __m128i, b[3]);
+        _mm_storeu_si128(blocks[4].as_mut_ptr() as *mut __m128i, b[4]);
+        _mm_storeu_si128(blocks[5].as_mut_ptr() as *mut __m128i, b[5]);
+        _mm_storeu_si128(blocks[6].as_mut_ptr() as *mut __m128i, b[6]);
+        _mm_storeu_si128(blocks[7].as_mut_ptr() as *mut __m128i, b[7]);
+    }
 }
 
-macro_rules! xor8 {
-    ($b:expr, $key:expr) => {
-        $b[0] = _mm_xor_si128($b[0], $key);
-        $b[1] = _mm_xor_si128($b[1], $key);
-        $b[2] = _mm_xor_si128($b[2], $key);
-        $b[3] = _mm_xor_si128($b[3], $key);
-        $b[4] = _mm_xor_si128($b[4], $key);
-        $b[5] = _mm_xor_si128($b[5], $key);
-        $b[6] = _mm_xor_si128($b[6], $key);
-        $b[7] = _mm_xor_si128($b[7], $key);
-    };
+#[inline(always)]
+pub(crate) fn xor8(b: &mut U128x8, key: __m128i) {
+    unsafe {
+        b[0] = _mm_xor_si128(b[0], key);
+        b[1] = _mm_xor_si128(b[1], key);
+        b[2] = _mm_xor_si128(b[2], key);
+        b[3] = _mm_xor_si128(b[3], key);
+        b[4] = _mm_xor_si128(b[4], key);
+        b[5] = _mm_xor_si128(b[5], key);
+        b[6] = _mm_xor_si128(b[6], key);
+        b[7] = _mm_xor_si128(b[7], key);
+    }
 }
 
-macro_rules! aesenc8 {
-    ($b:expr, $key:expr) => {
-        $b[0] = _mm_aesenc_si128($b[0], $key);
-        $b[1] = _mm_aesenc_si128($b[1], $key);
-        $b[2] = _mm_aesenc_si128($b[2], $key);
-        $b[3] = _mm_aesenc_si128($b[3], $key);
-        $b[4] = _mm_aesenc_si128($b[4], $key);
-        $b[5] = _mm_aesenc_si128($b[5], $key);
-        $b[6] = _mm_aesenc_si128($b[6], $key);
-        $b[7] = _mm_aesenc_si128($b[7], $key);
-    };
+#[inline(always)]
+pub(crate) fn aesenc8(b: &mut U128x8, key: __m128i) {
+    unsafe {
+        b[0] = _mm_aesenc_si128(b[0], key);
+        b[1] = _mm_aesenc_si128(b[1], key);
+        b[2] = _mm_aesenc_si128(b[2], key);
+        b[3] = _mm_aesenc_si128(b[3], key);
+        b[4] = _mm_aesenc_si128(b[4], key);
+        b[5] = _mm_aesenc_si128(b[5], key);
+        b[6] = _mm_aesenc_si128(b[6], key);
+        b[7] = _mm_aesenc_si128(b[7], key);
+    }
 }
 
-macro_rules! aesenclast8 {
-    ($b:expr, $key:expr) => {
-        $b[0] = _mm_aesenclast_si128($b[0], $key);
-        $b[1] = _mm_aesenclast_si128($b[1], $key);
-        $b[2] = _mm_aesenclast_si128($b[2], $key);
-        $b[3] = _mm_aesenclast_si128($b[3], $key);
-        $b[4] = _mm_aesenclast_si128($b[4], $key);
-        $b[5] = _mm_aesenclast_si128($b[5], $key);
-        $b[6] = _mm_aesenclast_si128($b[6], $key);
-        $b[7] = _mm_aesenclast_si128($b[7], $key);
-    };
+#[inline(always)]
+pub(crate) fn aesenclast8(b: &mut U128x8, key: __m128i) {
+    unsafe {
+        b[0] = _mm_aesenclast_si128(b[0], key);
+        b[1] = _mm_aesenclast_si128(b[1], key);
+        b[2] = _mm_aesenclast_si128(b[2], key);
+        b[3] = _mm_aesenclast_si128(b[3], key);
+        b[4] = _mm_aesenclast_si128(b[4], key);
+        b[5] = _mm_aesenclast_si128(b[5], key);
+        b[6] = _mm_aesenclast_si128(b[6], key);
+        b[7] = _mm_aesenclast_si128(b[7], key);
+    }
 }
 
-macro_rules! aesdec8 {
-    ($b:expr, $key:expr) => {
-        $b[0] = _mm_aesdec_si128($b[0], $key);
-        $b[1] = _mm_aesdec_si128($b[1], $key);
-        $b[2] = _mm_aesdec_si128($b[2], $key);
-        $b[3] = _mm_aesdec_si128($b[3], $key);
-        $b[4] = _mm_aesdec_si128($b[4], $key);
-        $b[5] = _mm_aesdec_si128($b[5], $key);
-        $b[6] = _mm_aesdec_si128($b[6], $key);
-        $b[7] = _mm_aesdec_si128($b[7], $key);
-    };
+#[inline(always)]
+pub(crate) fn aesdec8(b: &mut U128x8, key: __m128i) {
+    unsafe {
+        b[0] = _mm_aesdec_si128(b[0], key);
+        b[1] = _mm_aesdec_si128(b[1], key);
+        b[2] = _mm_aesdec_si128(b[2], key);
+        b[3] = _mm_aesdec_si128(b[3], key);
+        b[4] = _mm_aesdec_si128(b[4], key);
+        b[5] = _mm_aesdec_si128(b[5], key);
+        b[6] = _mm_aesdec_si128(b[6], key);
+        b[7] = _mm_aesdec_si128(b[7], key);
+    }
 }
 
-macro_rules! aesdeclast8 {
-    ($b:expr, $key:expr) => {
-        $b[0] = _mm_aesdeclast_si128($b[0], $key);
-        $b[1] = _mm_aesdeclast_si128($b[1], $key);
-        $b[2] = _mm_aesdeclast_si128($b[2], $key);
-        $b[3] = _mm_aesdeclast_si128($b[3], $key);
-        $b[4] = _mm_aesdeclast_si128($b[4], $key);
-        $b[5] = _mm_aesdeclast_si128($b[5], $key);
-        $b[6] = _mm_aesdeclast_si128($b[6], $key);
-        $b[7] = _mm_aesdeclast_si128($b[7], $key);
+#[inline(always)]
+pub(crate) fn aesdeclast8(b: &mut U128x8, key: __m128i) {
+    unsafe {
+        b[0] = _mm_aesdeclast_si128(b[0], key);
+        b[1] = _mm_aesdeclast_si128(b[1], key);
+        b[2] = _mm_aesdeclast_si128(b[2], key);
+        b[3] = _mm_aesdeclast_si128(b[3], key);
+        b[4] = _mm_aesdeclast_si128(b[4], key);
+        b[5] = _mm_aesdeclast_si128(b[5], key);
+        b[6] = _mm_aesdeclast_si128(b[6], key);
+        b[7] = _mm_aesdeclast_si128(b[7], key);
     };
 }

--- a/aes/src/ni/utils.rs
+++ b/aes/src/ni/utils.rs
@@ -6,9 +6,6 @@ use cipher::{
     generic_array::GenericArray,
 };
 
-#[cfg(test)]
-use core::mem;
-
 pub type Block128 = GenericArray<u8, U16>;
 pub type Block128x8 = GenericArray<GenericArray<u8, U16>, U8>;
 pub type U128x8 = [__m128i; 8];
@@ -16,7 +13,7 @@ pub type U128x8 = [__m128i; 8];
 #[cfg(test)]
 pub(crate) fn check(a: &[__m128i], b: &[[u64; 2]]) {
     for (v1, v2) in a.iter().zip(b) {
-        let t1: [u64; 2] = unsafe { mem::transmute(*v1) };
+        let t1: [u64; 2] = unsafe { core::mem::transmute(*v1) };
         let t2 = [v2[0].to_be(), v2[1].to_be()];
         assert_eq!(t1, t2);
     }


### PR DESCRIPTION
The previous usage of macros made refactoring extremely difficult, with small changes resulting in hundrdeds upon hundreds of errors when the macros are expanded, as opposed to a single error in a particular function.

This commit replaces the AES-NI `util.rs` macros with `#[inline(always)]` functions.

There is no change to the generated assembly.