### PR TITLE
Bump `cipher` dependency to v0.3 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.3.0-pre.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1db53c34251ece12ba40366dd5ece6dc5672296d7fb34f7b1791e8f0d449e69"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "blobby",
  "generic-array",
@@ -82,9 +82,9 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "ctr"
-version = "0.7.0-pre.3"
+version = "0.7.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa78b1c3f6ce4edd238882705f9589c9f2443bf541dd98d7b75aaa7ca91d4ba6"
+checksum = "a67a289177c60cd23d34d30b01c0ae773806016eeaf9718d58a9ad9dd1e96e45"
 dependencies = [
  "cipher",
 ]

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -16,12 +16,12 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "=0.3.0-pre.4"
-ctr = { version = "=0.7.0-pre.3", optional = true }
+cipher = "0.3"
+ctr = { version = "=0.7.0-pre.4", optional = true }
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpuid-bool = "0.2"

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["crypto", "block-cipher", "ciphers"]
 
 [dependencies]
 block-padding = "0.2"
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 
 [dev-dependencies]
 aes = { version = "=0.7.0-pre", path = "../aes", features = ["force-soft"] }

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["crypto", "blowfish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 byteorder = { version = "1", default-features = false }
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }
 
 [features]
 bcrypt = []

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["crypto", "cast5", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 opaque-debug = "0.3"
 byteorder = { version = "1", default-features = false }
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }
 hex-literal = "0.2"
 
 [features]

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -12,9 +12,9 @@ keywords = ["crypto", "des", "tdes", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 byteorder = { version = "1", default-features = false }
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }

--- a/gost-modes/Cargo.toml
+++ b/gost-modes/Cargo.toml
@@ -12,13 +12,13 @@ keywords = ["crypto", "block-cipher", "ciphers"]
 
 [dependencies]
 block-modes = { version = "=0.8.0-pre", path = "../block-modes", default-features = false }
-cipher = { version = "=0.3.0-pre.4", default-features = false }
+cipher = { version = "0.3", default-features = false }
 generic-array = "0.14"
 
 [dev-dependencies]
 kuznyechik = { version = "=0.7.0-pre", path = "../kuznyechik" }
 magma = { version = "=0.7.0-pre", path = "../magma" }
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }
 hex-literal = "0.2"
 
 [features]

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["crypto", "idea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["crypto", "kuznyechik", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }
 hex-literal = "0.2"
 
 [features]

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -12,9 +12,9 @@ keywords = ["crypto", "magma", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }
 hex-literal = "0.2"

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["crypto", "rc2", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["crypto", "sm4", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 byteorder = { version = "1", default-features = false }
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }
 hex-literal = "0.2"

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "threefish", "gost", "block-cipher"]
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-cipher = "=0.3.0-pre.4"
+cipher = "0.3"
 opaque-debug = "0.3"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3", features = ["dev"] }
 hex-literal = "0.2"


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/621