### PR TITLE
aes: use `cpufeatures` v0.1 crate release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.7.0-pre"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpuid-bool",
+ "cpufeatures",
  "ctr",
  "opaque-debug",
 ]
@@ -75,10 +75,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.2.0"
+name = "cpufeatures"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
 
 [[package]]
 name = "ctr"

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -24,7 +24,7 @@ opaque-debug = "0.3"
 cipher = { version = "0.3", features = ["dev"] }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
-cpuid-bool = "0.2"
+cpufeatures = "0.1"
 
 [features]
 compact = [] # Reduce code size at the cost of slower performance

--- a/aes/src/autodetect.rs
+++ b/aes/src/autodetect.rs
@@ -9,7 +9,7 @@ use cipher::{
 };
 use core::mem::ManuallyDrop;
 
-cpuid_bool::new!(aes_cpuid, "aes");
+cpufeatures::new!(aes_cpuid, "aes");
 
 macro_rules! define_aes_impl {
     (
@@ -136,7 +136,7 @@ pub(crate) mod ctr {
     };
     use core::mem::ManuallyDrop;
 
-    cpuid_bool::new!(aes_ssse3_cpuid, "aes", "ssse3");
+    cpufeatures::new!(aes_ssse3_cpuid, "aes", "ssse3");
 
     macro_rules! define_aes_ctr_impl {
         (


### PR DESCRIPTION
Renamed from `cpuid-bool`