### PR TITLE
aes: bump `ctr` crate dependency to v0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
 
 [[package]]
 name = "ctr"
-version = "0.7.0-pre.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67a289177c60cd23d34d30b01c0ae773806016eeaf9718d58a9ad9dd1e96e45"
+checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
  "cipher",
 ]

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 cfg-if = "1"
 cipher = "0.3"
-ctr = { version = "=0.7.0-pre.4", optional = true }
+ctr = { version = "0.7", optional = true }
 opaque-debug = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/stream-ciphers/pull/229