### PR TITLE
aes v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aes"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-04-29)
+### Added
+- Auto-detection support for AES-NI; MSRV 1.49+ ([#208], [#214], [#215], [#216])
+
+### Changed
+- Unify the `aes`, `aesni`, and `aes-soft` crates ([#200])
+- Use `cfg-if` crate ([#203])
+- Rename `semi_fixslice` feature to `compact` ([#204])
+- Refactor NI backend ([#224], [#225])
+- Bump `cipher` crate dependency to v0.3 release ([#235])
+- Bump `ctr` crate dependency to v0.7 ([#237])
+
+[#200]: https://github.com/RustCrypto/block-ciphers/pull/200
+[#203]: https://github.com/RustCrypto/block-ciphers/pull/203
+[#204]: https://github.com/RustCrypto/block-ciphers/pull/204
+[#208]: https://github.com/RustCrypto/block-ciphers/pull/208
+[#214]: https://github.com/RustCrypto/block-ciphers/pull/214
+[#215]: https://github.com/RustCrypto/block-ciphers/pull/215
+[#216]: https://github.com/RustCrypto/block-ciphers/pull/216
+[#224]: https://github.com/RustCrypto/block-ciphers/pull/224
+[#225]: https://github.com/RustCrypto/block-ciphers/pull/225
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+[#237]: https://github.com/RustCrypto/block-ciphers/pull/237
+
 ## 0.6.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = """
 Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)
 including support for AES in counter mode (a.k.a. AES-CTR)

--- a/aes/README.md
+++ b/aes/README.md
@@ -42,8 +42,7 @@ using a portable implementation based on bitslicing.
 
 ## Minimum Supported Rust Version
 
-- Rust **1.49** or higher.
-- Rust **1.41** is supported when the `force-soft` feature is enabled.
+Rust **1.49** or higher.
 
 Minimum supported Rust version can be changed in future releases, but it will
 be done with a minor version bump.

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -1,8 +1,10 @@
 //! Pure Rust implementation of the Advanced Encryption Standard
 //! (a.k.a. Rijndael)
 //!
-//! It provides two different backends based on what target features
-//! are specified:
+//! # Supported platforms
+//!
+//! This crate provides two different backends based on what target features
+//! are available:
 //!
 //! - "soft" portable constant-time implementation based on [fixslicing].
 //!   Enabling the `compact` Cargo feature will reduce the code size of this
@@ -12,8 +14,14 @@
 //!   architectures with `target-feature=+aes`, as well as an accelerated
 //!   AES-CTR implementation with `target-feature=+aes,+ssse3`
 //!
-//! Crate switches between implementations automatically at compile time.
-//! (i.e. it does not use run-time feature detection)
+//! By default this crate uses runtime detection on `i686`/`x86_64` targets
+//! in order to determine if AES-NI is available, and if it is not, it will
+//! fallback to using a constant-time software implementation.
+//!
+//! Passing `RUSTFLAGS=-Ctarget-feature=+aes,+ssse3` explicitly at compile-time
+//! will override runtime detection and ensure that AES-NI is always used.
+//! Programs built in this manner will crash with an illegal instruction on
+//! CPUs which do not have AES-NI enabled.
 //!
 //! # Usage example
 //! ```
@@ -26,12 +34,15 @@
 //! let key = GenericArray::from_slice(&[0u8; 16]);
 //! let mut block = GenericArray::clone_from_slice(&[0u8; 16]);
 //! let mut block8 = GenericArray::clone_from_slice(&[block; 8]);
+//!
 //! // Initialize cipher
 //! let cipher = Aes128::new(&key);
 //!
 //! let block_copy = block.clone();
+//!
 //! // Encrypt block in-place
 //! cipher.encrypt_block(&mut block);
+//!
 //! // And decrypt it back
 //! cipher.decrypt_block(&mut block);
 //! assert_eq!(block, block_copy);

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -15,7 +15,7 @@ block-padding = "0.2"
 cipher = "0.3"
 
 [dev-dependencies]
-aes = { version = "=0.7.0-pre", path = "../aes", features = ["force-soft"] }
+aes = { version = "0.7", path = "../aes", features = ["force-soft"] }
 hex-literal = "0.2"
 
 [features]


### PR DESCRIPTION
### Added
- Auto-detection support for AES-NI; MSRV 1.49+ ([#208], [#214], [#215], [#216])

### Changed
- Unify the `aes`, `aesni`, and `aes-soft` crates ([#200])
- Use `cfg-if` crate ([#203])
- Rename `semi_fixslice` feature to `compact` ([#204])
- Refactor NI backend ([#224], [#225])
- Bump `cipher` crate dependency to v0.3 release ([#235])
- Bump `ctr` crate dependency to v0.7 ([#237])

[#200]: https://github.com/RustCrypto/block-ciphers/pull/200
[#203]: https://github.com/RustCrypto/block-ciphers/pull/203
[#204]: https://github.com/RustCrypto/block-ciphers/pull/204
[#208]: https://github.com/RustCrypto/block-ciphers/pull/208
[#214]: https://github.com/RustCrypto/block-ciphers/pull/214
[#215]: https://github.com/RustCrypto/block-ciphers/pull/215
[#216]: https://github.com/RustCrypto/block-ciphers/pull/216
[#224]: https://github.com/RustCrypto/block-ciphers/pull/224
[#225]: https://github.com/RustCrypto/block-ciphers/pull/225
[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
[#237]: https://github.com/RustCrypto/block-ciphers/pull/237