### PR TITLE
Release `cipher` v0.3-based versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 
 [[package]]
 name = "block-modes"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "aes",
  "block-padding",
@@ -35,7 +35,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blowfish"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -50,7 +50,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cast5"
-version = "0.10.0-pre"
+version = "0.10.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "gost-modes"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "block-modes",
  "cipher",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "idea"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "magma"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -179,7 +179,7 @@ checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "rc2"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "serpent"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "sm4"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -206,14 +206,14 @@ dependencies = [
 
 [[package]]
 name = "threefish"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "twofish"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "byteorder",
  "cipher",

--- a/block-modes/CHANGELOG.md
+++ b/block-modes/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 0.8.0 (2021-04-29)
+### Added
+- `IvState` trait ([#227])
+
 ### Changed
 - Upgrade to `cipher v0.3` ([#202])
 
@@ -14,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#202]: https://github.com/RustCrypto/block-ciphers/pull/202
 [#211]: https://github.com/RustCrypto/block-ciphers/pull/211
+[#227]: https://github.com/RustCrypto/block-ciphers/pull/227
 
 ## 0.7.0 (2020-10-16)
 ### Changed

--- a/block-modes/Cargo.toml
+++ b/block-modes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-modes"
-version = "0.8.0-pre"
+version = "0.8.0"
 description = "Block cipher modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/blowfish/CHANGELOG.md
+++ b/blowfish/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.7.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blowfish"
-version = "0.8.0-pre"
+version = "0.8.0"
 description = "Blowfish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cast5/CHANGELOG.md
+++ b/cast5/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.9.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cast5"
-version = "0.10.0-pre"
+version = "0.10.0"
 description = "CAST5 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/des/CHANGELOG.md
+++ b/des/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.6.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "des"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/gost-modes/CHANGELOG.md
+++ b/gost-modes/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.4.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/gost-modes/Cargo.toml
+++ b/gost-modes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gost-modes"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = "Block cipher modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -11,13 +11,13 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "block-cipher", "ciphers"]
 
 [dependencies]
-block-modes = { version = "=0.8.0-pre", path = "../block-modes", default-features = false }
+block-modes = { version = "0.8", path = "../block-modes", default-features = false }
 cipher = { version = "0.3", default-features = false }
 generic-array = "0.14"
 
 [dev-dependencies]
-kuznyechik = { version = "=0.7.0-pre", path = "../kuznyechik" }
-magma = { version = "=0.7.0-pre", path = "../magma" }
+kuznyechik = { version = "0.7", path = "../kuznyechik" }
+magma = { version = "0.7", path = "../magma" }
 cipher = { version = "0.3", features = ["dev"] }
 hex-literal = "0.2"
 

--- a/idea/CHANGELOG.md
+++ b/idea/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.3.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idea"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "IDEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 AND MIT"

--- a/kuznyechik/CHANGELOG.md
+++ b/kuznyechik/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.6.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuznyechik"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/magma/CHANGELOG.md
+++ b/magma/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.6.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magma"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = "Magma (GOST 28147-89 and GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/rc2/CHANGELOG.md
+++ b/rc2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.6.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc2"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = "RC2 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/serpent/CHANGELOG.md
+++ b/serpent/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.3.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serpent"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Serpent block cipher"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/sm4/CHANGELOG.md
+++ b/sm4/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.3.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm4"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["andelf <andelf@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 description = "SM4 block cipher algorithm"

--- a/threefish/CHANGELOG.md
+++ b/threefish/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.3.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "threefish"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT OR Apache-2.0"
 description = "Threefish block cipher"

--- a/twofish/CHANGELOG.md
+++ b/twofish/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2021-04-29)
+### Changed
+- Bump `cipher` dependency to v0.3 release ([#235])
+
+[#235]: https://github.com/RustCrypto/block-ciphers/pull/235
+
 ## 0.5.0 (2020-10-16)
 ### Changed
 - Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#167])

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twofish"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "Twofish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases new versions of all crates in this repository which incorporate the `cipher` v0.3 release changes (RustCrypto/traits#621)