### PR TITLE
aes v0.7.1

### DIFF
--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2021-05-09)
+### Fixed
+- Restore `fixslice64.rs` ([#247])
+
+[#247]: https://github.com/RustCrypto/block-ciphers/pull/247
+
 ## 0.7.0 (2021-04-29)
 ### Added
 - Auto-detection support for AES-NI; MSRV 1.49+ ([#208], [#214], [#215], [#216])

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.7.0"
+version = "0.7.1"
 description = """
 Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)
 including support for AES in counter mode (a.k.a. AES-CTR)


### PR DESCRIPTION
### Fixed
- Restore `fixslice64.rs` ([#247])

[#247]: https://github.com/RustCrypto/block-ciphers/pull/247