### PR TITLE
aes: remove outdated docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/aes/src/ni.rs
+++ b/aes/src/ni.rs
@@ -1,28 +1,13 @@
 //! AES block ciphers implementation using AES-NI instruction set.
 //!
-//! This crate does not implement any software fallback and does not
-//! automatically check CPUID, so if you are using this crate make sure to run
-//! software on an appropriate hardware or to use software fallback
-//! (e.g. from [`aes-soft`](https://crates.io/crates/aes-soft) crate) with
-//! runtime detection of AES-NI availability (e.g. by using
-//! [`cupid`](https://crates.io/crates/cupid) crate).
-//!
-//! When using this crate do not forget to enable `aes` target feature,
-//! otherwise you will get a compilation error. You can do it either by using
-//! `RUSTFLAGS="-C target-feature=+aes"` or by editing your `.cargo/config`.
-//!
 //! Ciphers functionality is accessed using `BlockCipher` trait from the
 //! [`cipher`](https://docs.rs/cipher) crate.
 //!
 //! # CTR mode
 //! In addition to core block cipher functionality this crate provides optimized
-//! CTR mode implementation. This functionality requires additionall `ssse3`
+//! CTR mode implementation. This functionality requires additional `ssse3`
 //! target feature and feature-gated behind `ctr` feature flag, which is enabled
-//! by default. If you only need block ciphers, disable default features with
-//! `default-features = false` in your `Cargo.toml`.
-//!
-//! AES-CTR functionality is accessed using traits from
-//! [`cipher`](https://docs.rs/cipher) crate.
+//! by default.
 //!
 //! # Vulnerability
 //! Lazy FP state restory vulnerability can allow local process to leak content


### PR DESCRIPTION
These docs are leftover from the `aesni` crate and no longer describe the current state of the `aes` crate, namely that it now supports CPUID detection with a software fallback.