### PR TITLE
aes v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.2 (2021-05-17)
+### Added
+- Nightly-only ARMv8 intrinsics support gated under the `armv8` feature ([#250])
+
+[#250]: https://github.com/RustCrypto/block-ciphers/pull/250
+
 ## 0.7.1 (2021-05-09)
 ### Fixed
 - Restore `fixslice64.rs` ([#247])

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 description = """
 Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)
 including support for AES in counter mode (a.k.a. AES-CTR)


### PR DESCRIPTION
### Added
- Nightly-only ARMv8 intrinsics support gated under the `armv8` feature ([#250])

[#250]: https://github.com/RustCrypto/block-ciphers/pull/250