### PR TITLE
aes: expose raw round function API

### DIFF
--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -79,6 +79,7 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }} --features compact
       - run: cargo test --release --target ${{ matrix.target }} --features ctr
       - run: cargo test --release --target ${{ matrix.target }} --features force-soft
+      - run: cargo test --release --target ${{ matrix.target }} --features hazmat
 
   # Tests for CPU feature autodetection with fallback to portable software implementation
   autodetect:
@@ -111,6 +112,8 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }}
       - run: cargo test --release --target ${{ matrix.target }} --features compact
       - run: cargo test --release --target ${{ matrix.target }} --features ctr
+      - run: cargo test --release --target ${{ matrix.target }} --features hazmat
+      - run: cargo test --release --target ${{ matrix.target }} --all-features
 
   # Tests for the portable software backend (i.e. `force-soft`-only)
   soft:
@@ -200,6 +203,7 @@ jobs:
       - run: cross test --release --target ${{ matrix.target }} --features armv8,compact
       - run: cross test --release --target ${{ matrix.target }} --features armv8,ctr
       - run: cross test --release --target ${{ matrix.target }} --features armv8,force-soft
+      - run: cross test --release --target ${{ matrix.target }} --features armv8,hazmat
       - run: cross test --release --target ${{ matrix.target }} --all-features
 
   clippy:

--- a/aes/Cargo.lock
+++ b/aes/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -31,6 +31,7 @@ cpufeatures = "0.1.4"
 armv8      = [] # Enable ARMv8 AES intrinsics (nightly-only)
 compact    = [] # Reduce code size at the cost of slower performance
 force-soft = [] # Disable support for AES hardware intrinsics
+hazmat     = [] # Expose cryptographically hazardous APIs
 
 [package.metadata.docs.rs]
 features = ["ctr"]

--- a/aes/src/armv8.rs
+++ b/aes/src/armv8.rs
@@ -9,22 +9,25 @@
 
 #![allow(clippy::needless_range_loop)]
 
+#[cfg(feature = "hazmat")]
+pub(crate) mod round;
+
+mod decrypt;
+mod encrypt;
+mod expand;
+
+use self::{
+    decrypt::{decrypt, decrypt8},
+    encrypt::{encrypt, encrypt8},
+    expand::{expand_key, inv_expanded_keys},
+};
 use crate::{Block, ParBlocks};
 use cipher::{
     consts::{U16, U24, U32, U8},
     generic_array::GenericArray,
     BlockCipher, BlockDecrypt, BlockEncrypt, NewBlockCipher,
 };
-use core::{arch::aarch64::*, convert::TryInto, mem, slice};
-
-/// There are 4 AES words in a block.
-const BLOCK_WORDS: usize = 4;
-
-/// The AES (nee Rijndael) notion of a word is always 32-bits, or 4-bytes.
-const WORD_SIZE: usize = 4;
-
-/// AES round constants.
-const ROUND_CONSTS: [u32; 10] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36];
+use core::arch::aarch64::*;
 
 macro_rules! define_aes_impl {
     (
@@ -139,7 +142,7 @@ macro_rules! define_aes_impl {
         impl From<&$name_enc> for $name_dec {
             fn from(enc: &$name_enc) -> $name_dec {
                 let mut round_keys = enc.round_keys;
-                inverse_expanded_keys(&mut round_keys);
+                inv_expanded_keys(&mut round_keys);
                 Self { round_keys }
             }
         }
@@ -169,201 +172,6 @@ define_aes_impl!(Aes128, Aes128Enc, Aes128Dec, U16, 11, "AES-128");
 define_aes_impl!(Aes192, Aes192Enc, Aes192Dec, U24, 13, "AES-192");
 define_aes_impl!(Aes256, Aes256Enc, Aes256Dec, U32, 15, "AES-256");
 
-/// AES key expansion
-// TODO(tarcieri): big endian support?
-#[inline]
-fn expand_key<const L: usize, const N: usize>(key: &[u8; L]) -> [uint8x16_t; N] {
-    assert!((L == 16 && N == 11) || (L == 24 && N == 13) || (L == 32 && N == 15));
-
-    let mut expanded_keys: [uint8x16_t; N] = unsafe { mem::zeroed() };
-
-    // TODO(tarcieri): construct expanded keys using `vreinterpretq_u8_u32`
-    let ek_words = unsafe {
-        slice::from_raw_parts_mut(expanded_keys.as_mut_ptr() as *mut u32, N * BLOCK_WORDS)
-    };
-
-    for (i, chunk) in key.chunks_exact(WORD_SIZE).enumerate() {
-        ek_words[i] = u32::from_ne_bytes(chunk.try_into().unwrap());
-    }
-
-    // From "The Rijndael Block Cipher" Section 4.1:
-    // > The number of columns of the Cipher Key is denoted by `Nk` and is
-    // > equal to the key length divided by 32 [bits].
-    let nk = L / WORD_SIZE;
-
-    for i in nk..(N * BLOCK_WORDS) {
-        let mut word = ek_words[i - 1];
-
-        if i % nk == 0 {
-            word = sub_word(word).rotate_right(8) ^ ROUND_CONSTS[i / nk - 1];
-        } else if nk > 6 && i % nk == 4 {
-            word = sub_word(word)
-        }
-
-        ek_words[i] = ek_words[i - nk] ^ word;
-    }
-
-    expanded_keys
-}
-
-/// Compute inverse expanded keys (for decryption).
-///
-/// This is the reverse of the encryption keys, with the Inverse Mix Columns
-/// operation applied to all but the first and last expanded key.
-#[inline]
-fn inverse_expanded_keys<const N: usize>(expanded_keys: &mut [uint8x16_t; N]) {
-    assert!(N == 11 || N == 13 || N == 15);
-
-    for ek in expanded_keys.iter_mut().take(N - 1).skip(1) {
-        unsafe { *ek = vaesimcq_u8(*ek) }
-    }
-
-    expanded_keys.reverse();
-}
-
-/// Perform AES encryption using the given expanded keys.
-#[target_feature(enable = "crypto")]
-#[target_feature(enable = "neon")]
-unsafe fn encrypt<const N: usize>(expanded_keys: &[uint8x16_t; N], block: &mut Block) {
-    let rounds = N - 1;
-    assert!(rounds == 10 || rounds == 12 || rounds == 14);
-
-    let mut state = vld1q_u8(block.as_ptr());
-
-    for k in expanded_keys.iter().take(rounds - 1) {
-        // AES single round encryption
-        state = vaeseq_u8(state, *k);
-
-        // AES mix columns
-        state = vaesmcq_u8(state);
-    }
-
-    // AES single round encryption
-    state = vaeseq_u8(state, expanded_keys[rounds - 1]);
-
-    // Final add (bitwise XOR)
-    state = veorq_u8(state, expanded_keys[rounds]);
-
-    vst1q_u8(block.as_mut_ptr(), state);
-}
-
-/// Perform parallel AES encryption 8-blocks-at-a-time using the given expanded keys.
-#[target_feature(enable = "crypto")]
-#[target_feature(enable = "neon")]
-unsafe fn encrypt8<const N: usize>(expanded_keys: &[uint8x16_t; N], blocks: &mut ParBlocks) {
-    let rounds = N - 1;
-    assert!(rounds == 10 || rounds == 12 || rounds == 14);
-
-    let mut state = [
-        vld1q_u8(blocks[0].as_ptr()),
-        vld1q_u8(blocks[1].as_ptr()),
-        vld1q_u8(blocks[2].as_ptr()),
-        vld1q_u8(blocks[3].as_ptr()),
-        vld1q_u8(blocks[4].as_ptr()),
-        vld1q_u8(blocks[5].as_ptr()),
-        vld1q_u8(blocks[6].as_ptr()),
-        vld1q_u8(blocks[7].as_ptr()),
-    ];
-
-    for k in expanded_keys.iter().take(rounds - 1) {
-        for i in 0..8 {
-            // AES single round encryption
-            state[i] = vaeseq_u8(state[i], *k);
-
-            // AES mix columns
-            state[i] = vaesmcq_u8(state[i]);
-        }
-    }
-
-    for i in 0..8 {
-        // AES single round encryption
-        state[i] = vaeseq_u8(state[i], expanded_keys[rounds - 1]);
-
-        // Final add (bitwise XOR)
-        state[i] = veorq_u8(state[i], expanded_keys[rounds]);
-
-        vst1q_u8(blocks[i].as_mut_ptr(), state[i]);
-    }
-}
-
-/// Perform AES decryption using the given expanded keys.
-#[target_feature(enable = "crypto")]
-#[target_feature(enable = "neon")]
-unsafe fn decrypt<const N: usize>(expanded_keys: &[uint8x16_t; N], block: &mut Block) {
-    let rounds = N - 1;
-    assert!(rounds == 10 || rounds == 12 || rounds == 14);
-
-    let mut state = vld1q_u8(block.as_ptr());
-
-    for k in expanded_keys.iter().take(rounds - 1) {
-        // AES single round decryption
-        state = vaesdq_u8(state, *k);
-
-        // AES inverse mix columns
-        state = vaesimcq_u8(state);
-    }
-
-    // AES single round decryption
-    state = vaesdq_u8(state, expanded_keys[rounds - 1]);
-
-    // Final add (bitwise XOR)
-    state = veorq_u8(state, expanded_keys[rounds]);
-
-    vst1q_u8(block.as_mut_ptr(), state);
-}
-
-/// Perform parallel AES decryption 8-blocks-at-a-time using the given expanded keys.
-#[target_feature(enable = "crypto")]
-#[target_feature(enable = "neon")]
-unsafe fn decrypt8<const N: usize>(expanded_keys: &[uint8x16_t; N], blocks: &mut ParBlocks) {
-    let rounds = N - 1;
-    assert!(rounds == 10 || rounds == 12 || rounds == 14);
-
-    let mut state = [
-        vld1q_u8(blocks[0].as_ptr()),
-        vld1q_u8(blocks[1].as_ptr()),
-        vld1q_u8(blocks[2].as_ptr()),
-        vld1q_u8(blocks[3].as_ptr()),
-        vld1q_u8(blocks[4].as_ptr()),
-        vld1q_u8(blocks[5].as_ptr()),
-        vld1q_u8(blocks[6].as_ptr()),
-        vld1q_u8(blocks[7].as_ptr()),
-    ];
-
-    for k in expanded_keys.iter().take(rounds - 1) {
-        for i in 0..8 {
-            // AES single round decryption
-            state[i] = vaesdq_u8(state[i], *k);
-
-            // AES inverse mix columns
-            state[i] = vaesimcq_u8(state[i]);
-        }
-    }
-
-    for i in 0..8 {
-        // AES single round decryption
-        state[i] = vaesdq_u8(state[i], expanded_keys[rounds - 1]);
-
-        // Final add (bitwise XOR)
-        state[i] = veorq_u8(state[i], expanded_keys[rounds]);
-
-        vst1q_u8(blocks[i].as_mut_ptr(), state[i]);
-    }
-}
-
-/// Sub bytes for a single AES word: used for key expansion.
-#[inline(always)]
-fn sub_word(input: u32) -> u32 {
-    unsafe {
-        let input = vreinterpretq_u8_u32(vdupq_n_u32(input));
-
-        // AES single round encryption (with a "round" key of all zeros)
-        let sub_input = vaeseq_u8(input, vdupq_n_u8(0));
-
-        vgetq_lane_u32(vreinterpretq_u32_u8(sub_input), 0)
-    }
-}
-
 // TODO(tarcieri): use `stdarch` intrinsic for this when it becomes available
 #[inline(always)]
 unsafe fn vst1q_u8(dst: *mut u8, src: uint8x16_t) {
@@ -373,8 +181,7 @@ unsafe fn vst1q_u8(dst: *mut u8, src: uint8x16_t) {
 #[cfg(test)]
 mod tests {
     use super::{
-        decrypt, decrypt8, encrypt, encrypt8, expand_key, inverse_expanded_keys, vst1q_u8,
-        ParBlocks,
+        decrypt, decrypt8, encrypt, encrypt8, expand_key, inv_expanded_keys, vst1q_u8, ParBlocks,
     };
     use core::{arch::aarch64::*, convert::TryInto};
     use hex_literal::hex;
@@ -497,7 +304,7 @@ mod tests {
     #[test]
     fn aes128_key_expansion_inv() {
         let mut ek = load_expanded_keys(AES128_EXP_KEYS);
-        inverse_expanded_keys(&mut ek);
+        inv_expanded_keys(&mut ek);
         assert_eq!(store_expanded_keys(ek), AES128_EXP_INVKEYS);
     }
 

--- a/aes/src/armv8/decrypt.rs
+++ b/aes/src/armv8/decrypt.rs
@@ -1,0 +1,73 @@
+//! AES decryption support.
+
+use super::vst1q_u8;
+use crate::{Block, ParBlocks};
+use core::arch::aarch64::*;
+
+/// Perform AES decryption using the given expanded keys.
+#[target_feature(enable = "crypto")]
+#[target_feature(enable = "neon")]
+pub(super) unsafe fn decrypt<const N: usize>(expanded_keys: &[uint8x16_t; N], block: &mut Block) {
+    let rounds = N - 1;
+    assert!(rounds == 10 || rounds == 12 || rounds == 14);
+
+    let mut state = vld1q_u8(block.as_ptr());
+
+    for k in expanded_keys.iter().take(rounds - 1) {
+        // AES single round decryption
+        state = vaesdq_u8(state, *k);
+
+        // AES inverse mix columns
+        state = vaesimcq_u8(state);
+    }
+
+    // AES single round decryption
+    state = vaesdq_u8(state, expanded_keys[rounds - 1]);
+
+    // Final add (bitwise XOR)
+    state = veorq_u8(state, expanded_keys[rounds]);
+
+    vst1q_u8(block.as_mut_ptr(), state);
+}
+
+/// Perform parallel AES decryption 8-blocks-at-a-time using the given expanded keys.
+#[target_feature(enable = "crypto")]
+#[target_feature(enable = "neon")]
+pub(super) unsafe fn decrypt8<const N: usize>(
+    expanded_keys: &[uint8x16_t; N],
+    blocks: &mut ParBlocks,
+) {
+    let rounds = N - 1;
+    assert!(rounds == 10 || rounds == 12 || rounds == 14);
+
+    let mut state = [
+        vld1q_u8(blocks[0].as_ptr()),
+        vld1q_u8(blocks[1].as_ptr()),
+        vld1q_u8(blocks[2].as_ptr()),
+        vld1q_u8(blocks[3].as_ptr()),
+        vld1q_u8(blocks[4].as_ptr()),
+        vld1q_u8(blocks[5].as_ptr()),
+        vld1q_u8(blocks[6].as_ptr()),
+        vld1q_u8(blocks[7].as_ptr()),
+    ];
+
+    for k in expanded_keys.iter().take(rounds - 1) {
+        for i in 0..8 {
+            // AES single round decryption
+            state[i] = vaesdq_u8(state[i], *k);
+
+            // AES inverse mix columns
+            state[i] = vaesimcq_u8(state[i]);
+        }
+    }
+
+    for i in 0..8 {
+        // AES single round decryption
+        state[i] = vaesdq_u8(state[i], expanded_keys[rounds - 1]);
+
+        // Final add (bitwise XOR)
+        state[i] = veorq_u8(state[i], expanded_keys[rounds]);
+
+        vst1q_u8(blocks[i].as_mut_ptr(), state[i]);
+    }
+}

--- a/aes/src/armv8/encrypt.rs
+++ b/aes/src/armv8/encrypt.rs
@@ -1,0 +1,73 @@
+//! AES encryption support
+
+use super::vst1q_u8;
+use crate::{Block, ParBlocks};
+use core::arch::aarch64::*;
+
+/// Perform AES encryption using the given expanded keys.
+#[target_feature(enable = "crypto")]
+#[target_feature(enable = "neon")]
+pub(super) unsafe fn encrypt<const N: usize>(expanded_keys: &[uint8x16_t; N], block: &mut Block) {
+    let rounds = N - 1;
+    assert!(rounds == 10 || rounds == 12 || rounds == 14);
+
+    let mut state = vld1q_u8(block.as_ptr());
+
+    for k in expanded_keys.iter().take(rounds - 1) {
+        // AES single round encryption
+        state = vaeseq_u8(state, *k);
+
+        // AES mix columns
+        state = vaesmcq_u8(state);
+    }
+
+    // AES single round encryption
+    state = vaeseq_u8(state, expanded_keys[rounds - 1]);
+
+    // Final add (bitwise XOR)
+    state = veorq_u8(state, expanded_keys[rounds]);
+
+    vst1q_u8(block.as_mut_ptr(), state);
+}
+
+/// Perform parallel AES encryption 8-blocks-at-a-time using the given expanded keys.
+#[target_feature(enable = "crypto")]
+#[target_feature(enable = "neon")]
+pub(super) unsafe fn encrypt8<const N: usize>(
+    expanded_keys: &[uint8x16_t; N],
+    blocks: &mut ParBlocks,
+) {
+    let rounds = N - 1;
+    assert!(rounds == 10 || rounds == 12 || rounds == 14);
+
+    let mut state = [
+        vld1q_u8(blocks[0].as_ptr()),
+        vld1q_u8(blocks[1].as_ptr()),
+        vld1q_u8(blocks[2].as_ptr()),
+        vld1q_u8(blocks[3].as_ptr()),
+        vld1q_u8(blocks[4].as_ptr()),
+        vld1q_u8(blocks[5].as_ptr()),
+        vld1q_u8(blocks[6].as_ptr()),
+        vld1q_u8(blocks[7].as_ptr()),
+    ];
+
+    for k in expanded_keys.iter().take(rounds - 1) {
+        for i in 0..8 {
+            // AES single round encryption
+            state[i] = vaeseq_u8(state[i], *k);
+
+            // AES mix columns
+            state[i] = vaesmcq_u8(state[i]);
+        }
+    }
+
+    for i in 0..8 {
+        // AES single round encryption
+        state[i] = vaeseq_u8(state[i], expanded_keys[rounds - 1]);
+
+        // Final add (bitwise XOR)
+        state[i] = veorq_u8(state[i], expanded_keys[rounds]);
+
+        vst1q_u8(blocks[i].as_mut_ptr(), state[i]);
+    }
+}

--- a/aes/src/armv8/expand.rs
+++ b/aes/src/armv8/expand.rs
@@ -1,0 +1,77 @@
+//! AES key expansion support.
+
+use core::{arch::aarch64::*, convert::TryInto, mem, slice};
+
+/// There are 4 AES words in a block.
+const BLOCK_WORDS: usize = 4;
+
+/// The AES (nee Rijndael) notion of a word is always 32-bits, or 4-bytes.
+const WORD_SIZE: usize = 4;
+
+/// AES round constants.
+const ROUND_CONSTS: [u32; 10] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36];
+
+/// AES key expansion
+// TODO(tarcieri): big endian support?
+#[inline]
+pub(super) fn expand_key<const L: usize, const N: usize>(key: &[u8; L]) -> [uint8x16_t; N] {
+    assert!((L == 16 && N == 11) || (L == 24 && N == 13) || (L == 32 && N == 15));
+
+    let mut expanded_keys: [uint8x16_t; N] = unsafe { mem::zeroed() };
+
+    // TODO(tarcieri): construct expanded keys using `vreinterpretq_u8_u32`
+    let ek_words = unsafe {
+        slice::from_raw_parts_mut(expanded_keys.as_mut_ptr() as *mut u32, N * BLOCK_WORDS)
+    };
+
+    for (i, chunk) in key.chunks_exact(WORD_SIZE).enumerate() {
+        ek_words[i] = u32::from_ne_bytes(chunk.try_into().unwrap());
+    }
+
+    // From "The Rijndael Block Cipher" Section 4.1:
+    // > The number of columns of the Cipher Key is denoted by `Nk` and is
+    // > equal to the key length divided by 32 [bits].
+    let nk = L / WORD_SIZE;
+
+    for i in nk..(N * BLOCK_WORDS) {
+        let mut word = ek_words[i - 1];
+
+        if i % nk == 0 {
+            word = sub_word(word).rotate_right(8) ^ ROUND_CONSTS[i / nk - 1];
+        } else if nk > 6 && i % nk == 4 {
+            word = sub_word(word)
+        }
+
+        ek_words[i] = ek_words[i - nk] ^ word;
+    }
+
+    expanded_keys
+}
+
+/// Compute inverse expanded keys (for decryption).
+///
+/// This is the reverse of the encryption keys, with the Inverse Mix Columns
+/// operation applied to all but the first and last expanded key.
+#[inline]
+pub(super) fn inv_expanded_keys<const N: usize>(expanded_keys: &mut [uint8x16_t; N]) {
+    assert!(N == 11 || N == 13 || N == 15);
+
+    for ek in expanded_keys.iter_mut().take(N - 1).skip(1) {
+        unsafe { *ek = vaesimcq_u8(*ek) }
+    }
+
+    expanded_keys.reverse();
+}
+
+/// Sub bytes for a single AES word: used for key expansion.
+#[inline(always)]
+fn sub_word(input: u32) -> u32 {
+    unsafe {
+        let input = vreinterpretq_u8_u32(vdupq_n_u32(input));
+
+        // AES single round encryption (with a "round" key of all zeros)
+        let sub_input = vaeseq_u8(input, vdupq_n_u8(0));
+
+        vgetq_lane_u32(vreinterpretq_u32_u8(sub_input), 0)
+    }
+}

--- a/aes/src/armv8/round.rs
+++ b/aes/src/armv8/round.rs
@@ -1,0 +1,47 @@
+//! Raw AES round function: ARMv8 Cryptography Extensions support.
+//!
+//! Note: this isn't actually used in the `Aes128`/`Aes192`/`Aes256`
+//! implementations in this crate, but instead provides raw AES-NI accelerated
+//! access to the AES round function gated under the `hazmat` crate feature.
+
+use super::vst1q_u8;
+use crate::Block;
+use core::arch::aarch64::*;
+
+/// AES cipher (encrypt) round function.
+#[allow(clippy::cast_ptr_alignment)]
+#[target_feature(enable = "crypto")]
+pub(crate) unsafe fn cipher(block: &mut Block, round_key: &Block) {
+    let b = vld1q_u8(block.as_ptr());
+    let k = vld1q_u8(round_key.as_ptr());
+
+    // AES single round encryption (all-zero round key, deferred until the end)
+    let mut state = vaeseq_u8(b, vdupq_n_u8(0));
+
+    // AES mix columns (the `vaeseq_u8` instruction otherwise omits this step)
+    state = vaesmcq_u8(state);
+
+    // AES add round key (bitwise XOR)
+    state = veorq_u8(state, k);
+
+    vst1q_u8(block.as_mut_ptr(), state);
+}
+
+/// AES equivalent inverse cipher (decrypt) round function.
+#[allow(clippy::cast_ptr_alignment)]
+#[target_feature(enable = "crypto")]
+pub(crate) unsafe fn equiv_inv_cipher(block: &mut Block, round_key: &Block) {
+    let b = vld1q_u8(block.as_ptr());
+    let k = vld1q_u8(round_key.as_ptr());
+
+    // AES single round decryption (all-zero round key, deferred until the end)
+    let mut state = vaesdq_u8(b, vdupq_n_u8(0));
+
+    // AES inverse mix columns (the `vaesdq_u8` instruction otherwise omits this step)
+    state = vaesimcq_u8(state);
+
+    // AES add round key (bitwise XOR)
+    state = veorq_u8(state, k);
+
+    vst1q_u8(block.as_mut_ptr(), state);
+}

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -82,13 +82,19 @@
 //! [`block-modes`]: https://docs.rs/block-modes
 
 #![no_std]
+#![cfg_attr(
+    all(feature = "armv8", target_arch = "aarch64"),
+    feature(stdsimd, aarch64_target_feature)
+)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(feature = "armv8", feature(stdsimd, aarch64_target_feature))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
+
+#[cfg(all(feature = "hazmat", not(feature = "force-soft")))]
+pub mod round;
 
 mod soft;
 

--- a/aes/src/ni.rs
+++ b/aes/src/ni.rs
@@ -31,6 +31,9 @@ mod aes256;
 #[cfg(feature = "ctr")]
 mod ctr;
 
+#[cfg(feature = "hazmat")]
+pub(crate) mod round;
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86 as arch;
 #[cfg(target_arch = "x86_64")]

--- a/aes/src/ni/round.rs
+++ b/aes/src/ni/round.rs
@@ -1,0 +1,30 @@
+//! Raw AES round function: AES-NI support.
+//!
+//! Note: this isn't actually used in the `Aes128`/`Aes192`/`Aes256`
+//! implementations in this crate, but instead provides raw AES-NI accelerated
+//! access to the AES round function gated under the `hazmat` crate feature.
+
+use super::arch::*;
+use crate::Block;
+
+/// AES cipher (encrypt) round function.
+#[allow(clippy::cast_ptr_alignment)]
+#[target_feature(enable = "aes")]
+pub(crate) unsafe fn cipher(block: &mut Block, round_key: &Block) {
+    // Safety: `loadu` and `storeu` support unaligned access
+    let b = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+    let k = _mm_loadu_si128(round_key.as_ptr() as *const __m128i);
+    let out = _mm_aesenc_si128(b, k);
+    _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, out);
+}
+
+/// AES cipher (encrypt) round function.
+#[allow(clippy::cast_ptr_alignment)]
+#[target_feature(enable = "aes")]
+pub(crate) unsafe fn equiv_inv_cipher(block: &mut Block, round_key: &Block) {
+    // Safety: `loadu` and `storeu` support unaligned access
+    let b = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+    let k = _mm_loadu_si128(round_key.as_ptr() as *const __m128i);
+    let out = _mm_aesdec_si128(b, k);
+    _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, out);
+}

--- a/aes/src/round.rs
+++ b/aes/src/round.rs
@@ -1,0 +1,75 @@
+//! ⚠️ Raw AES round function.
+//!
+//! # ☢️️ WARNING: HAZARDOUS API ☢️
+//!
+//! This module contains an extremely low-level cryptographic primitive
+//! which is likewise extremely difficult to use correctly.
+//!
+//! There are very few valid uses cases for this API. It's intended to be used
+//! for implementing well-reviewed higher-level constructions.
+//!
+//! We do NOT recommending using it to implement any algorithm which has not
+//! received extensive peer review by cryptographers.
+
+use crate::Block;
+
+#[cfg(all(target_arch = "aarch64", feature = "armv8"))]
+use crate::armv8::round as intrinsics;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+use crate::ni::round as intrinsics;
+
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    all(target_arch = "aarch64", feature = "armv8")
+)))]
+compile_error!("the `hazmat` feature is currently only available on x86/x86-64 or aarch64");
+
+cpufeatures::new!(aes_intrinsics, "aes");
+
+/// ⚠️ AES cipher (encrypt) round function.
+///
+/// This API performs the following steps as described in FIPS 197 Appendix C:
+///
+/// - `s_box`: state after `SubBytes()`
+/// - `s_row`: state after `ShiftRows()`
+/// - `m_col`: state after `MixColumns()`
+/// - `k_sch`: key schedule value for `round[r]`
+///
+/// This series of operations is equivalent to the Intel AES-NI `AESENC` instruction.
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Use this function with great care! See the [module-level documentation][crate::round]
+/// for more information.
+pub fn cipher(block: &mut Block, round_key: &Block) {
+    if aes_intrinsics::init_get().1 {
+        unsafe { intrinsics::cipher(block, round_key) };
+    } else {
+        todo!("soft fallback for the raw AES round function API is not yet implemented");
+    }
+}
+
+/// ⚠️ AES equivalent inverse cipher (decrypt) round function.
+///
+/// This API performs the following steps as described in FIPS 197 Appendix C:
+///
+/// - `is_box`: state after `InvSubBytes()`
+/// - `is_row`: state after `InvShiftRows()`
+/// - `im_col`: state after `InvMixColumns()`
+/// - `ik_sch`: key schedule value for `round[r]`
+///
+/// This series of operations is equivalent to the Intel AES-NI `AESDEC` instruction.
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Use this function with great care! See the [module-level documentation][crate::round]
+/// for more information.
+pub fn equiv_inv_cipher(block: &mut Block, round_key: &Block) {
+    if aes_intrinsics::init_get().1 {
+        unsafe { intrinsics::equiv_inv_cipher(block, round_key) };
+    } else {
+        todo!("soft fallback for the raw AES round function API is not yet implemented");
+    }
+}

--- a/aes/tests/round.rs
+++ b/aes/tests/round.rs
@@ -1,0 +1,92 @@
+//! Tests for the raw AES round function.
+
+#![cfg(all(feature = "hazmat", not(feature = "force-soft")))]
+
+use aes::Block;
+use hex_literal::hex;
+
+/// Round function tests vectors.
+struct TestVector {
+    /// State at start of `round[r]`.
+    start: [u8; 16],
+
+    /// Key schedule value for `round[r]`.
+    k_sch: [u8; 16],
+
+    /// Cipher output.
+    output: [u8; 16],
+}
+
+/// Cipher round function test vectors from FIPS 197 Appendix C.1.
+const CIPHER_TEST_VECTORS: &[TestVector] = &[
+    // round 1
+    TestVector {
+        start: hex!("00102030405060708090a0b0c0d0e0f0"),
+        k_sch: hex!("d6aa74fdd2af72fadaa678f1d6ab76fe"),
+        output: hex!("89d810e8855ace682d1843d8cb128fe4"),
+    },
+    // round 2
+    TestVector {
+        start: hex!("89d810e8855ace682d1843d8cb128fe4"),
+        k_sch: hex!("b692cf0b643dbdf1be9bc5006830b3fe"),
+        output: hex!("4915598f55e5d7a0daca94fa1f0a63f7"),
+    },
+    // round 3
+    TestVector {
+        start: hex!("4915598f55e5d7a0daca94fa1f0a63f7"),
+        k_sch: hex!("b6ff744ed2c2c9bf6c590cbf0469bf41"),
+        output: hex!("fa636a2825b339c940668a3157244d17"),
+    },
+    // round 4
+    TestVector {
+        start: hex!("fa636a2825b339c940668a3157244d17"),
+        k_sch: hex!("47f7f7bc95353e03f96c32bcfd058dfd"),
+        output: hex!("247240236966b3fa6ed2753288425b6c"),
+    },
+];
+
+/// Equivalent Inverse Cipher round function test vectors from FIPS 197 Appendix C.1.
+const EQUIV_INV_CIPHER_TEST_VECTORS: &[TestVector] = &[
+    // round 1
+    TestVector {
+        start: hex!("7ad5fda789ef4e272bca100b3d9ff59f"),
+        k_sch: hex!("13aa29be9c8faff6f770f58000f7bf03"),
+        output: hex!("54d990a16ba09ab596bbf40ea111702f"),
+    },
+    // round 2
+    TestVector {
+        start: hex!("54d990a16ba09ab596bbf40ea111702f"),
+        k_sch: hex!("1362a4638f2586486bff5a76f7874a83"),
+        output: hex!("3e1c22c0b6fcbf768da85067f6170495"),
+    },
+    // round 3
+    TestVector {
+        start: hex!("3e1c22c0b6fcbf768da85067f6170495"),
+        k_sch: hex!("8d82fc749c47222be4dadc3e9c7810f5"),
+        output: hex!("b458124c68b68a014b99f82e5f15554c"),
+    },
+    // round 4
+    TestVector {
+        start: hex!("b458124c68b68a014b99f82e5f15554c"),
+        k_sch: hex!("72e3098d11c5de5f789dfe1578a2cccb"),
+        output: hex!("e8dab6901477d4653ff7f5e2e747dd4f"),
+    },
+];
+
+#[test]
+fn cipher_fips197_vectors() {
+    for vector in CIPHER_TEST_VECTORS {
+        let mut block = Block::from(vector.start);
+        aes::round::cipher(&mut block, &vector.k_sch.into());
+        assert_eq!(block.as_slice(), &vector.output);
+    }
+}
+
+#[test]
+fn equiv_inv_cipher_fips197_vectors() {
+    for vector in EQUIV_INV_CIPHER_TEST_VECTORS {
+        let mut block = Block::from(vector.start);
+        aes::round::equiv_inv_cipher(&mut block, &vector.k_sch.into());
+        assert_eq!(block.as_slice(), &vector.output);
+    }
+}


### PR DESCRIPTION
Closes #252

Exposes a `hazmat` (more like kryptonite) raw AES round function API intended for use in implementing things like CAESAR candidates (e.g. AEGIS, AEZ, Deoxys)

The current implementation only wraps hardware intrinsics and panics if they aren't available, however the goal is to provide a soft portable fallback as well.

Currently only exposes the "cipher" function (i.e. encryption). However, the goal is to support at least the "equivalent inverse cipher" function (ala Intel AES-NI's `AESDEC`) as well.

cc @zer0x64