### PR TITLE
aes: rename `hazmat` module; add `inv_mix_columns`

### DIFF
--- a/aes/src/armv8.rs
+++ b/aes/src/armv8.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::needless_range_loop)]
 
 #[cfg(feature = "hazmat")]
-pub(crate) mod round;
+pub(crate) mod hazmat;
 
 mod decrypt;
 mod encrypt;

--- a/aes/src/armv8/hazmat.rs
+++ b/aes/src/armv8/hazmat.rs
@@ -1,4 +1,4 @@
-//! Raw AES round function: ARMv8 Cryptography Extensions support.
+//! Low-level "hazmat" AES functions: ARMv8 Cryptography Extensions support.
 //!
 //! Note: this isn't actually used in the `Aes128`/`Aes192`/`Aes256`
 //! implementations in this crate, but instead provides raw AES-NI accelerated
@@ -11,7 +11,7 @@ use core::arch::aarch64::*;
 /// AES cipher (encrypt) round function.
 #[allow(clippy::cast_ptr_alignment)]
 #[target_feature(enable = "crypto")]
-pub(crate) unsafe fn cipher(block: &mut Block, round_key: &Block) {
+pub(crate) unsafe fn cipher_round(block: &mut Block, round_key: &Block) {
     let b = vld1q_u8(block.as_ptr());
     let k = vld1q_u8(round_key.as_ptr());
 
@@ -30,7 +30,7 @@ pub(crate) unsafe fn cipher(block: &mut Block, round_key: &Block) {
 /// AES equivalent inverse cipher (decrypt) round function.
 #[allow(clippy::cast_ptr_alignment)]
 #[target_feature(enable = "crypto")]
-pub(crate) unsafe fn equiv_inv_cipher(block: &mut Block, round_key: &Block) {
+pub(crate) unsafe fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block) {
     let b = vld1q_u8(block.as_ptr());
     let k = vld1q_u8(round_key.as_ptr());
 
@@ -44,4 +44,13 @@ pub(crate) unsafe fn equiv_inv_cipher(block: &mut Block, round_key: &Block) {
     state = veorq_u8(state, k);
 
     vst1q_u8(block.as_mut_ptr(), state);
+}
+
+/// AES inverse mix columns function.
+#[allow(clippy::cast_ptr_alignment)]
+#[target_feature(enable = "crypto")]
+pub(crate) unsafe fn inv_mix_columns(block: &mut Block) {
+    let b = vld1q_u8(block.as_ptr());
+    let out = vaesimcq_u8(b);
+    vst1q_u8(block.as_mut_ptr(), out);
 }

--- a/aes/src/hazmat.rs
+++ b/aes/src/hazmat.rs
@@ -1,4 +1,4 @@
-//! ⚠️ Raw AES round function.
+//! ⚠️ Low-level "hazmat" AES functions.
 //!
 //! # ☢️️ WARNING: HAZARDOUS API ☢️
 //!
@@ -14,10 +14,10 @@
 use crate::Block;
 
 #[cfg(all(target_arch = "aarch64", feature = "armv8"))]
-use crate::armv8::round as intrinsics;
+use crate::armv8::hazmat as intrinsics;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-use crate::ni::round as intrinsics;
+use crate::ni::hazmat as intrinsics;
 
 #[cfg(not(any(
     target_arch = "x86_64",
@@ -43,11 +43,11 @@ cpufeatures::new!(aes_intrinsics, "aes");
 ///
 /// Use this function with great care! See the [module-level documentation][crate::round]
 /// for more information.
-pub fn cipher(block: &mut Block, round_key: &Block) {
-    if aes_intrinsics::init_get().1 {
-        unsafe { intrinsics::cipher(block, round_key) };
+pub fn cipher_round(block: &mut Block, round_key: &Block) {
+    if aes_intrinsics::get() {
+        unsafe { intrinsics::cipher_round(block, round_key) };
     } else {
-        todo!("soft fallback for the raw AES round function API is not yet implemented");
+        todo!("soft fallback for AES hazmat functions is not yet implemented");
     }
 }
 
@@ -66,10 +66,26 @@ pub fn cipher(block: &mut Block, round_key: &Block) {
 ///
 /// Use this function with great care! See the [module-level documentation][crate::round]
 /// for more information.
-pub fn equiv_inv_cipher(block: &mut Block, round_key: &Block) {
-    if aes_intrinsics::init_get().1 {
-        unsafe { intrinsics::equiv_inv_cipher(block, round_key) };
+pub fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block) {
+    if aes_intrinsics::get() {
+        unsafe { intrinsics::equiv_inv_cipher_round(block, round_key) };
     } else {
-        todo!("soft fallback for the raw AES round function API is not yet implemented");
+        todo!("soft fallback for AES hazmat functions is not yet implemented");
+    }
+}
+
+/// ⚠️ AES inverse mix columns function.
+///
+/// This function is equivalent to the Intel AES-NI `AESIMC` instruction.
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Use this function with great care! See the [module-level documentation][crate::round]
+/// for more information.
+pub fn inv_mix_columns(block: &mut Block) {
+    if aes_intrinsics::get() {
+        unsafe { intrinsics::inv_mix_columns(block) };
+    } else {
+        todo!("soft fallback for AES hazmat functions is not yet implemented");
     }
 }

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -94,7 +94,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(all(feature = "hazmat", not(feature = "force-soft")))]
-pub mod round;
+pub mod hazmat;
 
 mod soft;
 

--- a/aes/src/ni.rs
+++ b/aes/src/ni.rs
@@ -32,7 +32,7 @@ mod aes256;
 mod ctr;
 
 #[cfg(feature = "hazmat")]
-pub(crate) mod round;
+pub(crate) mod hazmat;
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86 as arch;

--- a/aes/tests/hazmat.rs
+++ b/aes/tests/hazmat.rs
@@ -1,4 +1,4 @@
-//! Tests for the raw AES round function.
+//! Tests for low-level "hazmat" AES functions.
 
 #![cfg(all(feature = "hazmat", not(feature = "force-soft")))]
 
@@ -6,7 +6,7 @@ use aes::Block;
 use hex_literal::hex;
 
 /// Round function tests vectors.
-struct TestVector {
+struct RoundTestVector {
     /// State at start of `round[r]`.
     start: [u8; 16],
 
@@ -18,27 +18,27 @@ struct TestVector {
 }
 
 /// Cipher round function test vectors from FIPS 197 Appendix C.1.
-const CIPHER_TEST_VECTORS: &[TestVector] = &[
+const CIPHER_ROUND_TEST_VECTORS: &[RoundTestVector] = &[
     // round 1
-    TestVector {
+    RoundTestVector {
         start: hex!("00102030405060708090a0b0c0d0e0f0"),
         k_sch: hex!("d6aa74fdd2af72fadaa678f1d6ab76fe"),
         output: hex!("89d810e8855ace682d1843d8cb128fe4"),
     },
     // round 2
-    TestVector {
+    RoundTestVector {
         start: hex!("89d810e8855ace682d1843d8cb128fe4"),
         k_sch: hex!("b692cf0b643dbdf1be9bc5006830b3fe"),
         output: hex!("4915598f55e5d7a0daca94fa1f0a63f7"),
     },
     // round 3
-    TestVector {
+    RoundTestVector {
         start: hex!("4915598f55e5d7a0daca94fa1f0a63f7"),
         k_sch: hex!("b6ff744ed2c2c9bf6c590cbf0469bf41"),
         output: hex!("fa636a2825b339c940668a3157244d17"),
     },
     // round 4
-    TestVector {
+    RoundTestVector {
         start: hex!("fa636a2825b339c940668a3157244d17"),
         k_sch: hex!("47f7f7bc95353e03f96c32bcfd058dfd"),
         output: hex!("247240236966b3fa6ed2753288425b6c"),
@@ -46,27 +46,27 @@ const CIPHER_TEST_VECTORS: &[TestVector] = &[
 ];
 
 /// Equivalent Inverse Cipher round function test vectors from FIPS 197 Appendix C.1.
-const EQUIV_INV_CIPHER_TEST_VECTORS: &[TestVector] = &[
+const EQUIV_INV_CIPHER_ROUND_TEST_VECTORS: &[RoundTestVector] = &[
     // round 1
-    TestVector {
+    RoundTestVector {
         start: hex!("7ad5fda789ef4e272bca100b3d9ff59f"),
         k_sch: hex!("13aa29be9c8faff6f770f58000f7bf03"),
         output: hex!("54d990a16ba09ab596bbf40ea111702f"),
     },
     // round 2
-    TestVector {
+    RoundTestVector {
         start: hex!("54d990a16ba09ab596bbf40ea111702f"),
         k_sch: hex!("1362a4638f2586486bff5a76f7874a83"),
         output: hex!("3e1c22c0b6fcbf768da85067f6170495"),
     },
     // round 3
-    TestVector {
+    RoundTestVector {
         start: hex!("3e1c22c0b6fcbf768da85067f6170495"),
         k_sch: hex!("8d82fc749c47222be4dadc3e9c7810f5"),
         output: hex!("b458124c68b68a014b99f82e5f15554c"),
     },
     // round 4
-    TestVector {
+    RoundTestVector {
         start: hex!("b458124c68b68a014b99f82e5f15554c"),
         k_sch: hex!("72e3098d11c5de5f789dfe1578a2cccb"),
         output: hex!("e8dab6901477d4653ff7f5e2e747dd4f"),
@@ -74,19 +74,26 @@ const EQUIV_INV_CIPHER_TEST_VECTORS: &[TestVector] = &[
 ];
 
 #[test]
-fn cipher_fips197_vectors() {
-    for vector in CIPHER_TEST_VECTORS {
+fn cipher_round_fips197_vectors() {
+    for vector in CIPHER_ROUND_TEST_VECTORS {
         let mut block = Block::from(vector.start);
-        aes::round::cipher(&mut block, &vector.k_sch.into());
+        aes::hazmat::cipher_round(&mut block, &vector.k_sch.into());
         assert_eq!(block.as_slice(), &vector.output);
     }
 }
 
 #[test]
-fn equiv_inv_cipher_fips197_vectors() {
-    for vector in EQUIV_INV_CIPHER_TEST_VECTORS {
+fn equiv_inv_cipher_round_fips197_vectors() {
+    for vector in EQUIV_INV_CIPHER_ROUND_TEST_VECTORS {
         let mut block = Block::from(vector.start);
-        aes::round::equiv_inv_cipher(&mut block, &vector.k_sch.into());
+        aes::hazmat::equiv_inv_cipher_round(&mut block, &vector.k_sch.into());
         assert_eq!(block.as_slice(), &vector.output);
     }
+}
+
+#[test]
+fn inv_mix_columns_fips197_vector() {
+    let mut block = Block::from(hex!("bd6e7c3df2b5779e0b61216e8b10b689"));
+    aes::hazmat::inv_mix_columns(&mut block);
+    assert_eq!(block.as_slice(), &hex!("4773b91ff72f354361cb018ea1e6cf2c"))
 }


### PR DESCRIPTION
Renames the `round` module to `hazmat` to make it more general (and match the `hazmat` feature name).

Adds an `inv_mix_columns` function to it with backends for both the ARMv8 Cryptography Extensions as well as AES-NI.

cc @zer0x64 