### PR TITLE
aes: add `mix_columns` function to `hazmat` module

### DIFF
--- a/aes/src/armv8/hazmat.rs
+++ b/aes/src/armv8/hazmat.rs
@@ -46,6 +46,15 @@ pub(crate) unsafe fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block
     vst1q_u8(block.as_mut_ptr(), state);
 }
 
+/// AES mix columns function.
+#[allow(clippy::cast_ptr_alignment)]
+#[target_feature(enable = "crypto")]
+pub(crate) unsafe fn mix_columns(block: &mut Block) {
+    let b = vld1q_u8(block.as_ptr());
+    let out = vaesmcq_u8(b);
+    vst1q_u8(block.as_mut_ptr(), out);
+}
+
 /// AES inverse mix columns function.
 #[allow(clippy::cast_ptr_alignment)]
 #[target_feature(enable = "crypto")]

--- a/aes/src/hazmat.rs
+++ b/aes/src/hazmat.rs
@@ -74,6 +74,20 @@ pub fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block) {
     }
 }
 
+/// ⚠️ AES mix columns function.
+///
+/// # ☢️️ WARNING: HAZARDOUS API ☢️
+///
+/// Use this function with great care! See the [module-level documentation][crate::round]
+/// for more information.
+pub fn mix_columns(block: &mut Block) {
+    if aes_intrinsics::get() {
+        unsafe { intrinsics::mix_columns(block) };
+    } else {
+        todo!("soft fallback for AES hazmat functions is not yet implemented");
+    }
+}
+
 /// ⚠️ AES inverse mix columns function.
 ///
 /// This function is equivalent to the Intel AES-NI `AESIMC` instruction.

--- a/aes/src/ni/hazmat.rs
+++ b/aes/src/ni/hazmat.rs
@@ -29,6 +29,21 @@ pub(crate) unsafe fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block
     _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, out);
 }
 
+/// AES mix columns function.
+#[allow(clippy::cast_ptr_alignment)]
+#[target_feature(enable = "aes")]
+pub(crate) unsafe fn mix_columns(block: &mut Block) {
+    // Safety: `loadu` and `storeu` support unaligned access
+    let mut state = _mm_loadu_si128(block.as_ptr() as *const __m128i);
+
+    // Emulate mix columns by performing three inverse mix columns operations
+    state = _mm_aesimc_si128(state);
+    state = _mm_aesimc_si128(state);
+    state = _mm_aesimc_si128(state);
+
+    _mm_storeu_si128(block.as_mut_ptr() as *mut __m128i, state);
+}
+
 /// AES inverse mix columns function.
 #[allow(clippy::cast_ptr_alignment)]
 #[target_feature(enable = "aes")]

--- a/aes/tests/hazmat.rs
+++ b/aes/tests/hazmat.rs
@@ -92,6 +92,13 @@ fn equiv_inv_cipher_round_fips197_vectors() {
 }
 
 #[test]
+fn mix_columns_fips197_vector() {
+    let mut block = Block::from(hex!("6353e08c0960e104cd70b751bacad0e7"));
+    aes::hazmat::mix_columns(&mut block);
+    assert_eq!(block.as_slice(), &hex!("5f72641557f5bc92f7be3b291db9f91a"))
+}
+
+#[test]
 fn inv_mix_columns_fips197_vector() {
     let mut block = Block::from(hex!("bd6e7c3df2b5779e0b61216e8b10b689"));
     aes::hazmat::inv_mix_columns(&mut block);


### PR DESCRIPTION
Like the other functions in the `hazmat` module, this is presently an intrinsics-only implementation.

On ARMv8 we can use the dedicated `AESMC` instruction.

Intel AES-NI has no explicit instruction for mix columns, but it can be emulated by performing `AESIMC` (inverse mix columns) three times.

cc @zer0x64 