### PR TITLE
aes: add `BLOCK_SIZE` constant

### DIFF
--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -133,3 +133,6 @@ pub type Block = cipher::generic_array::GenericArray<u8, cipher::consts::U16>;
 
 /// 8 x 128-bit AES blocks to be processed in parallel
 pub type ParBlocks = cipher::generic_array::GenericArray<Block, cipher::consts::U8>;
+
+/// Size of an AES block (128-bits; 16-bytes)
+pub const BLOCK_SIZE: usize = 16;

--- a/aes/src/ni/ctr.rs
+++ b/aes/src/ni/ctr.rs
@@ -8,6 +8,7 @@ use super::arch::*;
 use core::mem;
 
 use super::{Aes128, Aes192, Aes256};
+use crate::BLOCK_SIZE;
 use cipher::{
     consts::U16,
     errors::{LoopError, OverflowError},
@@ -15,7 +16,6 @@ use cipher::{
     BlockCipher, FromBlockCipher, SeekNum, StreamCipher, StreamCipherSeek,
 };
 
-const BLOCK_SIZE: usize = 16;
 const PAR_BLOCKS: usize = 8;
 const PAR_BLOCKS_SIZE: usize = PAR_BLOCKS * BLOCK_SIZE;
 


### PR DESCRIPTION
I've found myself wanting this in downstream crates which consume this one. I think it could be also used in a number of places in the implementation of this crate in order to make it clearer.

It's also similar to the existing constant in the `polyval` crate:

https://docs.rs/polyval/0.5.0/polyval/constant.BLOCK_SIZE.html