### PR TITLE
aes v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2021-05-26)
+- `hazmat` feature/module providing round function access ([#257], [#259], [#260])
+- `BLOCK_SIZE` constant ([#263])
+
+[#257]: https://github.com/RustCrypto/block-ciphers/pull/257
+[#259]: https://github.com/RustCrypto/block-ciphers/pull/259
+[#260]: https://github.com/RustCrypto/block-ciphers/pull/260
+[#263]: https://github.com/RustCrypto/block-ciphers/pull/263
+
 ## 0.7.2 (2021-05-17)
 ### Added
 - Nightly-only ARMv8 intrinsics support gated under the `armv8` feature ([#250])

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.7.2"
+version = "0.7.3"
 description = """
 Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)
 including support for AES in counter mode (a.k.a. AES-CTR)

--- a/aes/src/hazmat.rs
+++ b/aes/src/hazmat.rs
@@ -41,7 +41,7 @@ cpufeatures::new!(aes_intrinsics, "aes");
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
 ///
-/// Use this function with great care! See the [module-level documentation][crate::round]
+/// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn cipher_round(block: &mut Block, round_key: &Block) {
     if aes_intrinsics::get() {
@@ -64,7 +64,7 @@ pub fn cipher_round(block: &mut Block, round_key: &Block) {
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
 ///
-/// Use this function with great care! See the [module-level documentation][crate::round]
+/// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block) {
     if aes_intrinsics::get() {
@@ -78,7 +78,7 @@ pub fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block) {
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
 ///
-/// Use this function with great care! See the [module-level documentation][crate::round]
+/// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn mix_columns(block: &mut Block) {
     if aes_intrinsics::get() {
@@ -94,7 +94,7 @@ pub fn mix_columns(block: &mut Block) {
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
 ///
-/// Use this function with great care! See the [module-level documentation][crate::round]
+/// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn inv_mix_columns(block: &mut Block) {
     if aes_intrinsics::get() {


### PR DESCRIPTION
- `hazmat` feature/module providing round function access ([#257], [#259], [#260])
- `BLOCK_SIZE` constant ([#263])

[#257]: https://github.com/RustCrypto/block-ciphers/pull/257
[#259]: https://github.com/RustCrypto/block-ciphers/pull/259
[#260]: https://github.com/RustCrypto/block-ciphers/pull/260
[#263]: https://github.com/RustCrypto/block-ciphers/pull/263