### PR TITLE
aes: soft `hazmat` modules

### DIFF
--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -93,7 +93,7 @@
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[cfg(all(feature = "hazmat", not(feature = "force-soft")))]
+#[cfg(feature = "hazmat")]
 pub mod hazmat;
 
 mod soft;

--- a/aes/src/soft/fixslice32.rs
+++ b/aes/src/soft/fixslice32.rs
@@ -1372,3 +1372,37 @@ fn rotate_rows_and_columns_2_2(x: u32) -> u32 {
     (ror(x, ror_distance(2, 2)) & 0x0f0f0f0f) |
     (ror(x, ror_distance(1, 2)) & 0xf0f0f0f0)
 }
+
+/// Low-level "hazmat" AES functions.
+///
+/// Note: this isn't actually used in the `Aes128`/`Aes192`/`Aes256`
+/// implementations in this crate, but instead provides raw access to
+/// the AES round function gated under the `hazmat` crate feature.
+#[cfg(feature = "hazmat")]
+pub(crate) mod hazmat {
+    use crate::Block;
+
+    /// AES cipher (encrypt) round function.
+    #[inline]
+    pub(crate) fn cipher_round(_block: &mut Block, _round_key: &Block) {
+        todo!();
+    }
+
+    /// AES cipher (encrypt) round function.
+    #[inline]
+    pub(crate) fn equiv_inv_cipher_round(_block: &mut Block, _round_key: &Block) {
+        todo!();
+    }
+
+    /// AES mix columns function.
+    #[inline]
+    pub(crate) fn mix_columns(_block: &mut Block) {
+        todo!();
+    }
+
+    /// AES inverse mix columns function.
+    #[inline]
+    pub(crate) fn inv_mix_columns(_block: &mut Block) {
+        todo!();
+    }
+}

--- a/aes/src/soft/fixslice64.rs
+++ b/aes/src/soft/fixslice64.rs
@@ -1426,3 +1426,37 @@ fn rotate_rows_and_columns_2_2(x: u64) -> u64 {
     (ror(x, ror_distance(2, 2)) & 0x00ff00ff00ff00ff) |
     (ror(x, ror_distance(1, 2)) & 0xff00ff00ff00ff00)
 }
+
+/// Low-level "hazmat" AES functions.
+///
+/// Note: this isn't actually used in the `Aes128`/`Aes192`/`Aes256`
+/// implementations in this crate, but instead provides raw access to
+/// the AES round function gated under the `hazmat` crate feature.
+#[cfg(feature = "hazmat")]
+pub(crate) mod hazmat {
+    use crate::Block;
+
+    /// AES cipher (encrypt) round function.
+    #[inline]
+    pub(crate) fn cipher_round(_block: &mut Block, _round_key: &Block) {
+        todo!();
+    }
+
+    /// AES cipher (encrypt) round function.
+    #[inline]
+    pub(crate) fn equiv_inv_cipher_round(_block: &mut Block, _round_key: &Block) {
+        todo!();
+    }
+
+    /// AES mix columns function.
+    #[inline]
+    pub(crate) fn mix_columns(_block: &mut Block) {
+        todo!();
+    }
+
+    /// AES inverse mix columns function.
+    #[inline]
+    pub(crate) fn inv_mix_columns(_block: &mut Block) {
+        todo!();
+    }
+}

--- a/aes/tests/hazmat.rs
+++ b/aes/tests/hazmat.rs
@@ -1,5 +1,6 @@
 //! Tests for low-level "hazmat" AES functions.
 
+// TODO(tarcieri): support for using the hazmat functions with the `soft` backend
 #![cfg(all(feature = "hazmat", not(feature = "force-soft")))]
 
 use aes::Block;


### PR DESCRIPTION
Adds a preliminary module structure for supporting the low-level `hazmat` APIs in the `soft` backend.