### PR TITLE
aes: expand CI coverage for `hazmat` feature

### DIFF
--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -41,6 +41,7 @@ jobs:
       - run: cargo build --release --target ${{ matrix.target }} --features compact
       - run: cargo build --release --target ${{ matrix.target }} --features ctr
       - run: cargo build --release --target ${{ matrix.target }} --features force-soft
+      - run: cargo build --release --target ${{ matrix.target }} --features hazmat
       - run: cargo build --release --target ${{ matrix.target }} --features compact,ctr,force-soft
 
   # Tests for the AES-NI backend
@@ -80,6 +81,7 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }} --features ctr
       - run: cargo test --release --target ${{ matrix.target }} --features force-soft
       - run: cargo test --release --target ${{ matrix.target }} --features hazmat
+      - run: cargo test --release --target ${{ matrix.target }} --all-features
 
   # Tests for CPU feature autodetection with fallback to portable software implementation
   autodetect:
@@ -146,7 +148,7 @@ jobs:
       - run: cargo test --release --target ${{ matrix.target }} --features force-soft
       - run: cargo test --release --target ${{ matrix.target }} --features force-soft,compact
       - run: cargo test --release --target ${{ matrix.target }} --features force-soft,ctr
-      - run: cargo build --release --target ${{ matrix.target }} --features compact,ctr,force-soft
+      - run: cargo test --release --target ${{ matrix.target }} --features force-soft,compact,ctr
 
   # Cross-compiled tests
   cross:
@@ -179,7 +181,8 @@ jobs:
       - run: cross test --release --target ${{ matrix.target }} --features compact
       - run: cross test --release --target ${{ matrix.target }} --features ctr
       - run: cross test --release --target ${{ matrix.target }} --features force-soft
-      - run: cross test --release --target ${{ matrix.target }} --features compact,ctr,force-soft
+      - run: cross test --release --target ${{ matrix.target }} --features hazmat
+      - run: cross test --release --target ${{ matrix.target }} --features compact,ctr,force-soft,hazmat
 
   # ARMv8 cross-compiled tests for AES intrinsics (nightly-only)
   armv8:
@@ -216,4 +219,4 @@ jobs:
           components: clippy
           override: true
           profile: minimal
-      - run: cargo clippy --features compact,ctr,force-soft -- -D warnings
+      - run: cargo clippy --features compact,ctr,hazmat -- -D warnings

--- a/aes/src/hazmat.rs
+++ b/aes/src/hazmat.rs
@@ -26,7 +26,14 @@ use crate::armv8::hazmat as intrinsics;
 ))]
 use crate::ni::hazmat as intrinsics;
 
-#[cfg(not(feature = "force-soft"))]
+#[cfg(all(
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "armv8")
+    ),
+    not(feature = "force-soft")
+))]
 cpufeatures::new!(aes_intrinsics, "aes");
 
 /// ⚠️ AES cipher (encrypt) round function.
@@ -45,7 +52,14 @@ cpufeatures::new!(aes_intrinsics, "aes");
 /// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn cipher_round(block: &mut Block, round_key: &Block) {
-    #[cfg(not(feature = "force-soft"))]
+    #[cfg(all(
+        any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "armv8")
+        ),
+        not(feature = "force-soft")
+    ))]
     if aes_intrinsics::get() {
         unsafe { intrinsics::cipher_round(block, round_key) };
         return;
@@ -64,7 +78,14 @@ pub fn cipher_round(block: &mut Block, round_key: &Block) {
 /// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn cipher_round_par(blocks: &mut ParBlocks, round_keys: &ParBlocks) {
-    #[cfg(not(feature = "force-soft"))]
+    #[cfg(all(
+        any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "armv8")
+        ),
+        not(feature = "force-soft")
+    ))]
     if aes_intrinsics::get() {
         unsafe { intrinsics::cipher_round_par(blocks, round_keys) };
         return;
@@ -89,7 +110,14 @@ pub fn cipher_round_par(blocks: &mut ParBlocks, round_keys: &ParBlocks) {
 /// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block) {
-    #[cfg(not(feature = "force-soft"))]
+    #[cfg(all(
+        any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "armv8")
+        ),
+        not(feature = "force-soft")
+    ))]
     if aes_intrinsics::get() {
         unsafe { intrinsics::equiv_inv_cipher_round(block, round_key) };
         return;
@@ -98,7 +126,7 @@ pub fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block) {
     soft::equiv_inv_cipher_round(block, round_key);
 }
 
-/// ⚠️ AES equivalent inverse cipher (decrypt) round function.
+/// ⚠️ AES equivalent inverse cipher (decrypt) round function: parallel version.
 ///
 /// Equivalent to [`equiv_inv_cipher_round`], but acts on 8 blocks-at-a-time,
 /// applying the same number of round keys.
@@ -108,7 +136,14 @@ pub fn equiv_inv_cipher_round(block: &mut Block, round_key: &Block) {
 /// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn equiv_inv_cipher_round_par(blocks: &mut ParBlocks, round_keys: &ParBlocks) {
-    #[cfg(not(feature = "force-soft"))]
+    #[cfg(all(
+        any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "armv8")
+        ),
+        not(feature = "force-soft")
+    ))]
     if aes_intrinsics::get() {
         unsafe { intrinsics::equiv_inv_cipher_round_par(blocks, round_keys) };
         return;
@@ -124,7 +159,14 @@ pub fn equiv_inv_cipher_round_par(blocks: &mut ParBlocks, round_keys: &ParBlocks
 /// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn mix_columns(block: &mut Block) {
-    #[cfg(not(feature = "force-soft"))]
+    #[cfg(all(
+        any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "armv8")
+        ),
+        not(feature = "force-soft")
+    ))]
     if aes_intrinsics::get() {
         unsafe { intrinsics::mix_columns(block) };
         return;
@@ -142,7 +184,14 @@ pub fn mix_columns(block: &mut Block) {
 /// Use this function with great care! See the [module-level documentation][crate::hazmat]
 /// for more information.
 pub fn inv_mix_columns(block: &mut Block) {
-    #[cfg(not(feature = "force-soft"))]
+    #[cfg(all(
+        any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "armv8")
+        ),
+        not(feature = "force-soft")
+    ))]
     if aes_intrinsics::get() {
         unsafe { intrinsics::inv_mix_columns(block) };
         return;

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -109,7 +109,7 @@ cfg_if! {
         #[cfg(feature = "ctr")]
         pub use autodetect::ctr::{Aes128Ctr, Aes192Ctr, Aes256Ctr};
     } else if #[cfg(all(
-        any(target_arch = "x86_64", target_arch = "x86"),
+        any(target_arch = "x86", target_arch = "x86_64"),
         not(feature = "force-soft")
     ))] {
         mod autodetect;


### PR DESCRIPTION
Now that the `hazmat` feature supports the "soft" backend, this adds additional coverage checks to ensure it works in all of the various environments we support.