### PR TITLE
aes v0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.4 (2021-06-01)
+### Added
+- Soft `hazmat` backend ([#267], [#268])
+- Parallel `hazmat` APIs ([#269])
+
+[#267]: https://github.com/RustCrypto/block-ciphers/pull/267
+[#268]: https://github.com/RustCrypto/block-ciphers/pull/268
+[#269]: https://github.com/RustCrypto/block-ciphers/pull/269
+
 ## 0.7.3 (2021-05-26)
+### Added
 - `hazmat` feature/module providing round function access ([#257], [#259], [#260])
 - `BLOCK_SIZE` constant ([#263])
 

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.7.3"
+version = "0.7.4"
 description = """
 Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)
 including support for AES in counter mode (a.k.a. AES-CTR)


### PR DESCRIPTION
### Added
- Soft `hazmat` backend ([#267], [#268])
- Parallel `hazmat` APIs ([#269])

[#267]: https://github.com/RustCrypto/block-ciphers/pull/267
[#268]: https://github.com/RustCrypto/block-ciphers/pull/268
[#269]: https://github.com/RustCrypto/block-ciphers/pull/269