### PR TITLE
aes: use `core::arch::aarch64::vst1q_u8` intrinsic on `armv8`

### DIFF
--- a/aes/Cargo.lock
+++ b/aes/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -38,18 +38,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "opaque-debug"

--- a/aes/src/armv8.rs
+++ b/aes/src/armv8.rs
@@ -172,17 +172,9 @@ define_aes_impl!(Aes128, Aes128Enc, Aes128Dec, U16, 11, "AES-128");
 define_aes_impl!(Aes192, Aes192Enc, Aes192Dec, U24, 13, "AES-192");
 define_aes_impl!(Aes256, Aes256Enc, Aes256Dec, U32, 15, "AES-256");
 
-// TODO(tarcieri): use `stdarch` intrinsic for this when it becomes available
-#[inline(always)]
-unsafe fn vst1q_u8(dst: *mut u8, src: uint8x16_t) {
-    dst.copy_from_nonoverlapping(&src as *const _ as *const u8, 16);
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        decrypt, decrypt8, encrypt, encrypt8, expand_key, inv_expanded_keys, vst1q_u8, ParBlocks,
-    };
+    use super::{decrypt, decrypt8, encrypt, encrypt8, expand_key, inv_expanded_keys, ParBlocks};
     use core::{arch::aarch64::*, convert::TryInto};
     use hex_literal::hex;
 

--- a/aes/src/armv8/decrypt.rs
+++ b/aes/src/armv8/decrypt.rs
@@ -1,6 +1,5 @@
 //! AES decryption support.
 
-use super::vst1q_u8;
 use crate::{Block, ParBlocks};
 use core::arch::aarch64::*;
 

--- a/aes/src/armv8/encrypt.rs
+++ b/aes/src/armv8/encrypt.rs
@@ -1,6 +1,5 @@
 //! AES encryption support
 
-use super::vst1q_u8;
 use crate::{Block, ParBlocks};
 use core::arch::aarch64::*;
 

--- a/aes/src/armv8/hazmat.rs
+++ b/aes/src/armv8/hazmat.rs
@@ -4,7 +4,6 @@
 //! implementations in this crate, but instead provides raw AES-NI accelerated
 //! access to the AES round function gated under the `hazmat` crate feature.
 
-use super::vst1q_u8;
 use crate::{Block, ParBlocks};
 use core::arch::aarch64::*;
 


### PR DESCRIPTION
It previously wasn't mapped, but it is now:

https://doc.rust-lang.org/core/arch/aarch64/fn.vst1q_u8.html