### PR TITLE
aes: bump `cpufeatures` dependency to v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "9cc47dfc37fe9455a291c6aef98ac51376b771fa9779aa7a2f9a86f0700a7a20"
 dependencies = [
  "libc",
 ]
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "magma"

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -25,7 +25,7 @@ cipher = { version = "0.3", features = ["dev"] }
 hex-literal = "0.2"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
-cpufeatures = "0.1.5"
+cpufeatures = "0.2"
 
 [features]
 armv8      = [] # Enable ARMv8 AES intrinsics (nightly-only)


### PR DESCRIPTION
This release incorporates the removal of the `crypto` target feature from nightly rustc.