### PR TITLE
aes: expose helper functions about hardware acceleration detection

### DIFF
--- a/aes/src/autodetect.rs
+++ b/aes/src/autodetect.rs
@@ -17,6 +17,11 @@ use crate::ni as intrinsics;
 
 cpufeatures::new!(aes_intrinsics, "aes");
 
+/// Returns whether hardware acceleration will be used for AES.
+pub fn is_hwaccel_available() -> bool {
+    aes_intrinsics::get()
+}
+
 macro_rules! define_aes_impl {
     (
         $name:tt,
@@ -159,6 +164,11 @@ pub(crate) mod ctr {
     use core::mem::ManuallyDrop;
 
     cpufeatures::new!(aes_ssse3_cpuid, "aes", "ssse3");
+
+    /// Returns whether hardware acceleration will be used for AES in CTR mode.
+    pub fn is_ctr_hwaccel_available() -> bool {
+        aes_ssse3_cpuid::get()
+    }
 
     macro_rules! define_aes_ctr_impl {
         (

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -104,7 +104,7 @@ cfg_if! {
     if #[cfg(all(target_arch = "aarch64", feature = "armv8", not(feature = "force-soft")))] {
         mod armv8;
         mod autodetect;
-        pub use autodetect::{Aes128, Aes192, Aes256};
+        pub use autodetect::{Aes128, Aes192, Aes256, is_hwaccel_available};
 
         #[cfg(feature = "ctr")]
         pub use autodetect::ctr::{Aes128Ctr, Aes192Ctr, Aes256Ctr};
@@ -114,10 +114,10 @@ cfg_if! {
     ))] {
         mod autodetect;
         mod ni;
-        pub use autodetect::{Aes128, Aes192, Aes256};
+        pub use autodetect::{Aes128, Aes192, Aes256, is_hwaccel_available};
 
         #[cfg(feature = "ctr")]
-        pub use autodetect::ctr::{Aes128Ctr, Aes192Ctr, Aes256Ctr};
+        pub use autodetect::ctr::{Aes128Ctr, Aes192Ctr, Aes256Ctr, is_ctr_hwaccel_available};
     } else {
         pub use soft::{Aes128, Aes192, Aes256};
 


### PR DESCRIPTION
First of all, thanks for you great work on those crates.

To explain a bit our usecase, we want to be able to use different AEAD algorithms
depending on whether one will use the hardware extension instructions or not.
So, we would like to be able to know if the AES algorithm will be hardware accelerated,
and depending on this information, pick AES-GCM or another algorithm.

Instead of using a cpufeatures check on our side which risks being desynced from
the real check used in the aes crate, exposing a function that returns whether
hw acceleration will be used would be more sound.

Please tell me if this feature is ok with you and/or if you would do it another way,
I tried to put it in the place it made more sense to me, but it's all open to modifications.
Thanks!