### PR TITLE
twofish: Derive Clone for Twofish.

### DIFF
--- a/twofish/src/lib.rs
+++ b/twofish/src/lib.rs
@@ -25,6 +25,7 @@ use crate::consts::{MDS_POLY, QBOX, QORD, RS, RS_POLY};
 type Block = GenericArray<u8, U16>;
 
 /// Twofish block cipher
+#[derive(Clone)]
 pub struct Twofish {
     s: [u8; 16],  // S-box key
     k: [u32; 40], // Subkeys


### PR DESCRIPTION
This aligns Twofish with AES.  Among other things, it allows its use
with EAX with requires Clone.