### PR TITLE
aes: Add some SAFETY comments to the `aes::ni` module

### DIFF
--- a/aes/src/ni/aes192/expand.rs
+++ b/aes/src/ni/aes192/expand.rs
@@ -37,6 +37,8 @@ macro_rules! shuffle {
 #[inline(always)]
 pub(super) fn expand(key: &[u8; 24]) -> (RoundKeys, RoundKeys) {
     unsafe {
+        // SAFETY: `RoundKeys` is a `[__m128i; 13]` which can be initialized
+        // with all zeroes.
         let mut enc_keys: RoundKeys = mem::zeroed();
         let mut dec_keys: RoundKeys = mem::zeroed();
 

--- a/aes/src/ni/aes256/expand.rs
+++ b/aes/src/ni/aes256/expand.rs
@@ -62,7 +62,9 @@ macro_rules! expand_round_last {
 
 #[inline(always)]
 pub(super) fn expand(key: &[u8; 32]) -> (RoundKeys, RoundKeys) {
-    // Safety: `loadu` and `storeu` support unaligned access
+    // SAFETY:
+    // - `RoundKeys` is a `[__m128i; 15]` which can be initialized with all zeroes.
+    // - `loadu` and `storeu` support unaligned access
     #[allow(clippy::cast_ptr_alignment)]
     unsafe {
         let mut enc_keys: RoundKeys = mem::zeroed();

--- a/aes/src/ni/ctr.rs
+++ b/aes/src/ni/ctr.rs
@@ -83,6 +83,8 @@ macro_rules! impl_ctr {
             #[inline(always)]
             fn gen_block(&mut self) {
                 let block = self.cipher.encrypt(swap_bytes(self.ctr));
+                // SAFETY: All three expansions of this macro have a `$cipher` whose
+                // `encrypt(...)` method returns an `__m128i`, and `BLOCK_SIZE == 16`.
                 self.block = unsafe { mem::transmute(block) }
             }
 
@@ -96,6 +98,7 @@ macro_rules! impl_ctr {
             #[inline(always)]
             fn next_block8(&mut self) -> [__m128i; 8] {
                 let mut ctr = self.ctr;
+                // SAFETY: `[__m128i; 8]` can be initialized with all zeroes.
                 let mut block8: [__m128i; 8] = unsafe { mem::zeroed() };
                 for i in 0..8 {
                     block8[i] = swap_bytes(ctr);


### PR DESCRIPTION
Suggested during review of `aes-gcm` for inclusion in Fuchsia OS:
https://fuchsia-review.googlesource.com/c/fuchsia/+/585023