### PR TITLE
Fix missing no-std category for SM4

### DIFF
--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/RustCrypto/block-ciphers/tree/master/sm4"
 readme = "README.md"
 edition = "2018"
 keywords = ["crypto", "sm4", "block-cipher"]
-categories = ["cryptography"]
+categories = ["cryptography", "no-std"]
 
 [dependencies]
 cipher = "0.3"


### PR DESCRIPTION
I don't see a reason why `no-std` shouldn't be added here?