### PR TITLE
Update dependencies to build with cargo update -Z minimal-versions

### DIFF
--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cipher = "0.3"
-byteorder = { version = "1", default-features = false }
+byteorder = { version = "1.1.0", default-features = false }
 opaque-debug = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
It also would be appreciated to release a new version of blockfish with an updated byteorder dependency because it's not a dev-dependency unlike other updated dependencies.

Not committing Cargo.lock is recommended, as libraries cannot really control what dependencies Cargo downloads, and as such it makes sense to test newest versions of dependencies on CI.