### PR TITLE
Fix missing space before curly brace

### DIFF
--- a/camellia/src/camellia.rs
+++ b/camellia/src/camellia.rs
@@ -284,7 +284,7 @@ macro_rules! impl_camellia {
         #[cfg(feature = "zeroize")]
         #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
         impl Drop for $name {
-            fn drop(&mut self){
+            fn drop(&mut self) {
                 self.k.zeroize();
             }
         }


### PR DESCRIPTION
This is a mistake in #293.