### PR TITLE
ParBlocksSizeUser impls

### DIFF
--- a/aes/src/armv8.rs
+++ b/aes/src/armv8.rs
@@ -110,6 +110,10 @@ macro_rules! define_aes_impl {
             }
         }
 
+        impl ParBlocksSizeUser for $name {
+            type ParBlocksSize = U8;
+        }
+
         impl fmt::Debug for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
                 f.write_str(concat!(stringify!($name), " { .. }"))

--- a/aes/src/ni.rs
+++ b/aes/src/ni.rs
@@ -121,6 +121,10 @@ macro_rules! define_aes_impl {
             }
         }
 
+        impl ParBlocksSizeUser for $name {
+            type ParBlocksSize = U8;
+        }
+
         impl fmt::Debug for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
                 f.write_str(concat!(stringify!($name), " { .. }"))

--- a/aes/src/soft.rs
+++ b/aes/src/soft.rs
@@ -86,6 +86,10 @@ macro_rules! define_aes_impl {
             }
         }
 
+        impl ParBlocksSizeUser for $name {
+            type ParBlocksSize = FixsliceBlocks;
+        }
+
         impl From<$name_enc> for $name {
             #[inline]
             fn from(enc: $name_enc) -> $name {

--- a/kuznyechik/src/soft/mod.rs
+++ b/kuznyechik/src/soft/mod.rs
@@ -1,7 +1,7 @@
 use crate::{BlockSize, Key, KeySize};
 use cipher::{
-    AlgorithmName, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, KeyInit,
-    KeySizeUser,
+    consts::U1, AlgorithmName, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt,
+    BlockSizeUser, KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 use core::fmt;
 
@@ -63,6 +63,10 @@ impl BlockDecrypt for Kuznyechik {
     fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut DecBackend(&self.keys));
     }
+}
+
+impl ParBlocksSizeUser for Kuznyechik {
+    type ParBlocksSize = U1;
 }
 
 impl fmt::Debug for Kuznyechik {

--- a/kuznyechik/src/sse2/backends.rs
+++ b/kuznyechik/src/sse2/backends.rs
@@ -13,7 +13,7 @@ use core::arch::x86_64::*;
 
 pub(super) type RoundKeys = [__m128i; 10];
 
-type ParBlocksSize = U4;
+pub(crate) type ParBlocksSize = U4;
 
 #[rustfmt::skip]
 macro_rules! unroll_par {

--- a/kuznyechik/src/sse2/mod.rs
+++ b/kuznyechik/src/sse2/mod.rs
@@ -3,7 +3,7 @@
 use crate::{BlockSize, Key, KeySize};
 use cipher::{
     AlgorithmName, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, KeyInit,
-    KeySizeUser,
+    KeySizeUser, ParBlocksSizeUser,
 };
 use core::fmt;
 
@@ -70,6 +70,10 @@ impl BlockDecrypt for Kuznyechik {
     fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut DecBackend(&self.dec_keys));
     }
+}
+
+impl ParBlocksSizeUser for Kuznyechik {
+    type ParBlocksSize = backends::ParBlocksSize;
 }
 
 impl fmt::Debug for Kuznyechik {


### PR DESCRIPTION
This impls `ParBlocksSizeUser` for AES and Kuznyechik block ciphers. `ParBlocksSizeUser` was already impl'd for their backends, so this was a matter of copy-pasting.

This unblocks the fix for https://github.com/RustCrypto/AEADs/issues/410