### PR TITLE
aes: remove use of `aarch64_target_feature`

### DIFF
--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -15,17 +15,23 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 cfg-if = "1"
 cipher = "0.4.2"
-zeroize = { version = "1.5.6", optional = true, default_features = false }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
+
+[target.'cfg(not(all(aes_armv8, target_arch = "aarch64")))'.dependencies]
+zeroize = { version = "1.5.6", optional = true, default_features = false }
+
+# TODO(tarcieri): unconditionally enable `aarch64` feature when MSRV is 1.59
+[target.'cfg(all(aes_armv8, target_arch = "aarch64"))'.dependencies]
+zeroize = { version = "1.5.6", optional = true, default_features = false, features = ["aarch64"] }
 
 [dev-dependencies]
 cipher = { version = "0.4.2", features = ["dev"] }
 hex-literal = "0.3"
 
 [features]
-hazmat     = [] # Expose cryptographically hazardous APIs
+hazmat = [] # Expose cryptographically hazardous APIs
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -120,12 +120,10 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms)]
-#![cfg_attr(
-    all(aes_armv8, target_arch = "aarch64"),
-    feature(stdsimd, aarch64_target_feature)
-)]
+#![cfg_attr(all(aes_armv8, target_arch = "aarch64"), feature(stdsimd))]
 
 #[cfg(feature = "hazmat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "hazmat")))]
 pub mod hazmat;
 
 mod soft;


### PR DESCRIPTION
It's been stabilized: rust-lang/rust#90620

Because of that, it's breaking the build on recent nightlies:

https://github.com/RustCrypto/block-ciphers/runs/7968517726?check_suite_focus=true#step:7:103

> error: the feature `aarch64_target_feature` has been stable since 1.61.0 and no longer requires an attribute to enable