### PR TITLE
belt-block: add belt_block_raw function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "magma"

--- a/belt-block/CHANGELOG.md
+++ b/belt-block/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.1 (2022-09-23)
 ### Added
-- `belt_block_raw` function ([#333])
+- `belt_block_raw` function and `cipher` crate feature (enabled by default) ([#333])
 
 [#333]: https://github.com/RustCrypto/block-ciphers/pull/333
 

--- a/belt-block/CHANGELOG.md
+++ b/belt-block/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2022-09-23)
+### Added
+- `belt_block_raw` function ([#333])
+
+[#333]: https://github.com/RustCrypto/block-ciphers/pull/333
+
 ## 0.1.0 (2022-09-14)
 - Initial release ([#328])
 

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -12,13 +12,14 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "belt-block", "belt", "stb"]
 
 [dependencies]
-cipher = "0.4.3"
+cipher = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
 cipher = { version = "0.4.3", features = ["dev"] }
 hex-literal = "0.3.4"
 
 [features]
+default = ["cipher"]
 zeroize = ["cipher/zeroize"]
 
 [package.metadata.docs.rs]

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-block"
-version = "0.1.0"
+version = "0.1.1"
 description = "belt-block block cipher implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/belt-block/README.md
+++ b/belt-block/README.md
@@ -8,7 +8,7 @@
 [![Build Status][build-image]][build-link]
 [![HAZMAT][hazmat-image]][hazmat-link]
 
-Pure Rust implementation of the [belt-block][1].
+Pure Rust implementation of the [BelT] block cipher specified in [STB 34.101.31-2020].
 
 [Documentation][docs-link]
 
@@ -68,4 +68,5 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
-[1]: https://ru.wikipedia.org/wiki/BelT
+[BelT]: https://ru.wikipedia.org/wiki/BelT
+[STB 34.101.31-2020]: http://apmi.bsu.by/assets/files/std/belt-spec371.pdf

--- a/belt-block/src/cipher_impl.rs
+++ b/belt-block/src/cipher_impl.rs
@@ -1,0 +1,145 @@
+use crate::{belt_block_raw, g13, g21, g5, key_idx};
+use cipher::consts::{U16, U32};
+use cipher::{inout::InOut, AlgorithmName, Block, BlockCipher, Key, KeyInit, KeySizeUser};
+use core::{fmt, mem::swap, num::Wrapping};
+
+#[cfg(feature = "zeroize")]
+use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// BelT block cipher.
+#[derive(Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "cipher")))]
+pub struct BeltBlock {
+    key: [u32; 8],
+}
+
+impl BeltBlock {
+    /// Encryption as described in section 6.1.3
+    #[inline]
+    fn encrypt(&self, mut block: InOut<'_, '_, Block<Self>>) {
+        let block_in = block.get_in();
+        // Steps 1 and 4
+        let x = [
+            get_u32(block_in, 0),
+            get_u32(block_in, 1),
+            get_u32(block_in, 2),
+            get_u32(block_in, 3),
+        ];
+
+        let y = belt_block_raw(x, &self.key);
+
+        let block_out = block.get_out();
+        // 6) Y ← b ‖ d ‖ a ‖ c
+        for i in 0..4 {
+            set_u32(block_out, &y, i);
+        }
+    }
+
+    /// Decryption as described in section 6.1.4
+    #[inline]
+    fn decrypt(&self, mut block: InOut<'_, '_, Block<Self>>) {
+        let key = &self.key;
+        let block_in = block.get_in();
+        // Steps 1 and 4
+        let mut a = Wrapping(get_u32(block_in, 0));
+        let mut b = Wrapping(get_u32(block_in, 1));
+        let mut c = Wrapping(get_u32(block_in, 2));
+        let mut d = Wrapping(get_u32(block_in, 3));
+
+        // Step 5
+        for i in (1..9).rev() {
+            // 5.1) b ← b ⊕ G₅(a ⊞ 𝑘[7i])
+            b ^= g5(a + key_idx(key, i, 0));
+            // 5.2) c ← c ⊕ G₂₁(d ⊞ 𝑘[7i-1])
+            c ^= g21(d + key_idx(key, i, 1));
+            // 5.3) a ← a ⊟ G₁₃(b ⊞ 𝑘[7i-2])
+            a -= g13(b + key_idx(key, i, 2));
+            // 5.4) e ← G₂₁(b ⊞ c ⊞ 𝑘[7i-3]) ⊕ ⟨i⟩₃₂
+            let e = g21(b + c + key_idx(key, i, 3)) ^ Wrapping(i as u32);
+            // 5.5) b ← b ⊞ e
+            b += e;
+            // 5.6) c ← c ⊟ e
+            c -= e;
+            // 5.7) d ← d ⊞ G₁₃(c ⊞ 𝑘[7i-4])
+            d += g13(c + key_idx(key, i, 4));
+            // 5.8) b ← b ⊕ G₂₁(a ⊞ 𝑘[7i-5])
+            b ^= g21(a + key_idx(key, i, 5));
+            // 5.9) c ← c ⊕ G₅(d ⊞ 𝑘[7i-6])
+            c ^= g5(d + key_idx(key, i, 6));
+            // 5.10) a ↔ b
+            swap(&mut a, &mut b);
+            // 5.11) c ↔ d
+            swap(&mut c, &mut d);
+            // 5.12) a ↔ d
+            swap(&mut a, &mut d);
+        }
+
+        let block_out = block.get_out();
+        // 6) 𝑋 ← c ‖ a ‖ d ‖ b
+        let x = [c.0, a.0, d.0, b.0];
+        for i in 0..4 {
+            set_u32(block_out, &x, i);
+        }
+    }
+}
+
+impl BlockCipher for BeltBlock {}
+
+impl KeySizeUser for BeltBlock {
+    type KeySize = U32;
+}
+
+impl KeyInit for BeltBlock {
+    fn new(key: &Key<Self>) -> Self {
+        Self {
+            key: [
+                get_u32(key, 0),
+                get_u32(key, 1),
+                get_u32(key, 2),
+                get_u32(key, 3),
+                get_u32(key, 4),
+                get_u32(key, 5),
+                get_u32(key, 6),
+                get_u32(key, 7),
+            ],
+        }
+    }
+}
+
+impl AlgorithmName for BeltBlock {
+    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("BeltBlock")
+    }
+}
+
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+impl Drop for BeltBlock {
+    fn drop(&mut self) {
+        self.key.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+impl ZeroizeOnDrop for BeltBlock {}
+
+cipher::impl_simple_block_encdec!(
+    BeltBlock, U16, cipher, block,
+    encrypt: {
+        cipher.encrypt(block);
+    }
+    decrypt: {
+        cipher.decrypt(block);
+    }
+);
+
+#[inline(always)]
+fn get_u32(block: &[u8], i: usize) -> u32 {
+    u32::from_le_bytes(block[4 * i..][..4].try_into().unwrap())
+}
+
+#[inline(always)]
+fn set_u32(block: &mut [u8], val: &[u32; 4], i: usize) {
+    block[4 * i..][..4].copy_from_slice(&val[i].to_le_bytes());
+}

--- a/belt-block/src/lib.rs
+++ b/belt-block/src/lib.rs
@@ -1,4 +1,5 @@
-//! Pure Rust implementation of the [BelT] block cipher.
+//! Pure Rust implementation of the [BelT] block cipher specified in
+//! [STB 34.101.31-2020].
 //!
 //! # ⚠️ Security Warning: Hazmat!
 //!
@@ -9,6 +10,7 @@
 //! USE AT YOUR OWN RISK!
 //!
 //! [BelT]: https://ru.wikipedia.org/wiki/BelT
+//! [STB 34.101.31-2020]: http://apmi.bsu.by/assets/files/std/belt-spec371.pdf
 
 #![no_std]
 #![doc(

--- a/belt-block/src/lib.rs
+++ b/belt-block/src/lib.rs
@@ -19,16 +19,18 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
-use crate::consts::{H13, H21, H29, H5};
+#[cfg(feature = "cipher")]
 pub use cipher;
-use cipher::consts::{U16, U32};
-use cipher::{inout::InOut, AlgorithmName, Block, BlockCipher, Key, KeyInit, KeySizeUser};
-use core::{fmt, mem::swap, num::Wrapping};
 
+use crate::consts::{H13, H21, H29, H5};
+use core::{mem::swap, num::Wrapping};
+
+#[cfg(feature = "cipher")]
+mod cipher_impl;
 mod consts;
 
-#[cfg(feature = "zeroize")]
-use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
+#[cfg(feature = "cipher")]
+pub use cipher_impl::BeltBlock;
 
 macro_rules! g {
     ($($name:ident: ($a:expr, $b:expr, $c:expr, $d:expr)),+) => {
@@ -49,22 +51,6 @@ g!(
     g13: (H5, H29, H21, H13),
     g21: (H13, H5, H29, H21)
 );
-
-/// BelT block cipher.
-#[derive(Clone)]
-pub struct BeltBlock {
-    key: [u32; 8],
-}
-
-#[inline(always)]
-fn get_u32(block: &[u8], i: usize) -> u32 {
-    u32::from_le_bytes(block[4 * i..][..4].try_into().unwrap())
-}
-
-#[inline(always)]
-fn set_u32(block: &mut [u8], val: &[u32; 4], i: usize) {
-    block[4 * i..][..4].copy_from_slice(&val[i].to_le_bytes());
-}
 
 #[inline(always)]
 fn key_idx(key: &[u32; 8], i: usize, delta: usize) -> Wrapping<u32> {
@@ -111,124 +97,3 @@ pub fn belt_block_raw(x: [u32; 4], key: &[u32; 8]) -> [u32; 4] {
     // Step 6
     [b.0, d.0, a.0, c.0]
 }
-
-impl BeltBlock {
-    /// Encryption as described in section 6.1.3
-    #[inline]
-    fn encrypt(&self, mut block: InOut<'_, '_, Block<Self>>) {
-        let block_in = block.get_in();
-        // Steps 1 and 4
-        let x = [
-            get_u32(block_in, 0),
-            get_u32(block_in, 1),
-            get_u32(block_in, 2),
-            get_u32(block_in, 3),
-        ];
-
-        let y = belt_block_raw(x, &self.key);
-
-        let block_out = block.get_out();
-        // 6) Y ← b ‖ d ‖ a ‖ c
-        for i in 0..4 {
-            set_u32(block_out, &y, i);
-        }
-    }
-
-    /// Decryption as described in section 6.1.4
-    #[inline]
-    fn decrypt(&self, mut block: InOut<'_, '_, Block<Self>>) {
-        let key = &self.key;
-        let block_in = block.get_in();
-        // Steps 1 and 4
-        let mut a = Wrapping(get_u32(block_in, 0));
-        let mut b = Wrapping(get_u32(block_in, 1));
-        let mut c = Wrapping(get_u32(block_in, 2));
-        let mut d = Wrapping(get_u32(block_in, 3));
-
-        // Step 5
-        for i in (1..9).rev() {
-            // 5.1) b ← b ⊕ G₅(a ⊞ 𝑘[7i])
-            b ^= g5(a + key_idx(key, i, 0));
-            // 5.2) c ← c ⊕ G₂₁(d ⊞ 𝑘[7i-1])
-            c ^= g21(d + key_idx(key, i, 1));
-            // 5.3) a ← a ⊟ G₁₃(b ⊞ 𝑘[7i-2])
-            a -= g13(b + key_idx(key, i, 2));
-            // 5.4) e ← G₂₁(b ⊞ c ⊞ 𝑘[7i-3]) ⊕ ⟨i⟩₃₂
-            let e = g21(b + c + key_idx(key, i, 3)) ^ Wrapping(i as u32);
-            // 5.5) b ← b ⊞ e
-            b += e;
-            // 5.6) c ← c ⊟ e
-            c -= e;
-            // 5.7) d ← d ⊞ G₁₃(c ⊞ 𝑘[7i-4])
-            d += g13(c + key_idx(key, i, 4));
-            // 5.8) b ← b ⊕ G₂₁(a ⊞ 𝑘[7i-5])
-            b ^= g21(a + key_idx(key, i, 5));
-            // 5.9) c ← c ⊕ G₅(d ⊞ 𝑘[7i-6])
-            c ^= g5(d + key_idx(key, i, 6));
-            // 5.10) a ↔ b
-            swap(&mut a, &mut b);
-            // 5.11) c ↔ d
-            swap(&mut c, &mut d);
-            // 5.12) a ↔ d
-            swap(&mut a, &mut d);
-        }
-
-        let block_out = block.get_out();
-        // 6) 𝑋 ← c ‖ a ‖ d ‖ b
-        let x = [c.0, a.0, d.0, b.0];
-        for i in 0..4 {
-            set_u32(block_out, &x, i);
-        }
-    }
-}
-
-impl BlockCipher for BeltBlock {}
-
-impl KeySizeUser for BeltBlock {
-    type KeySize = U32;
-}
-
-impl KeyInit for BeltBlock {
-    fn new(key: &Key<Self>) -> Self {
-        Self {
-            key: [
-                get_u32(key, 0),
-                get_u32(key, 1),
-                get_u32(key, 2),
-                get_u32(key, 3),
-                get_u32(key, 4),
-                get_u32(key, 5),
-                get_u32(key, 6),
-                get_u32(key, 7),
-            ],
-        }
-    }
-}
-
-impl AlgorithmName for BeltBlock {
-    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("BeltBlock")
-    }
-}
-
-#[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl Drop for BeltBlock {
-    fn drop(&mut self) {
-        self.key.zeroize();
-    }
-}
-
-#[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl ZeroizeOnDrop for BeltBlock {}
-
-cipher::impl_simple_block_encdec!(
-    BeltBlock, U16, cipher, block,
-    encrypt: {
-        cipher.encrypt(block);
-    }
-    decrypt: {
-        cipher.decrypt(block);
-    }
-);


### PR DESCRIPTION
Also makes implementation of the `cipher` traits gated on enabled by default `cipher` feature.