### PR TITLE
rc5: post-merge cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "rc5"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "cipher",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ members = [
     "kuznyechik",
     "magma",
     "rc2",
+    "rc5",
     "serpent",
     "sm4",
     "twofish",
     "threefish",
-    "rc5"
 ]
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ It's generally recommended not to use other cipher implementations in this repos
 | [IDEA] | [`idea`] | [![crates.io](https://img.shields.io/crates/v/idea.svg)](https://crates.io/crates/idea) | [![Documentation](https://docs.rs/idea/badge.svg)](https://docs.rs/idea) | ![MSRV 1.56][msrv-1.56] |
 | [Kuznyechik] (GOST R 34.12-2015)  | [`kuznyechik`] | [![crates.io](https://img.shields.io/crates/v/kuznyechik.svg)](https://crates.io/crates/kuznyechik) | [![Documentation](https://docs.rs/kuznyechik/badge.svg)](https://docs.rs/kuznyechik) | ![MSRV 1.56][msrv-1.56] |
 | [Magma] (GOST R 34.12-2015) | [`magma`] | [![crates.io](https://img.shields.io/crates/v/magma.svg)](https://crates.io/crates/magma) | [![Documentation](https://docs.rs/magma/badge.svg)](https://docs.rs/magma) | ![MSRV 1.56][msrv-1.56] |
-| [RC2] (ARC2) | [`rc2`] | [![crates.io](https://img.shields.io/crates/v/rc2.svg)](https://crates.io/crates/rc2) | [![Documentation](https://docs.rs/rc2/badge.svg)](https://docs.rs/rc2) | ![MSRV 1.56][msrv-1.56] |
 | [Serpent] | [`serpent`] | [![crates.io](https://img.shields.io/crates/v/serpent.svg)](https://crates.io/crates/serpent) | [![Documentation](https://docs.rs/serpent/badge.svg)](https://docs.rs/serpent) | ![MSRV 1.56][msrv-1.56] |
+| [RC2] (ARC2) | [`rc2`] | [![crates.io](https://img.shields.io/crates/v/rc2.svg)](https://crates.io/crates/rc2) | [![Documentation](https://docs.rs/rc2/badge.svg)](https://docs.rs/rc2) | ![MSRV 1.56][msrv-1.56] |
+| [RC5] | [`rc5`] | [![crates.io](https://img.shields.io/crates/v/rc5.svg)](https://crates.io/crates/rc5) | [![Documentation](https://docs.rs/rc5/badge.svg)](https://docs.rs/rc5) | ![MSRV 1.56][msrv-1.56] |
 | [SM4] | [`sm4`] | [![crates.io](https://img.shields.io/crates/v/sm4.svg)](https://crates.io/crates/sm4) | [![Documentation](https://docs.rs/sm4/badge.svg)](https://docs.rs/sm4) | ![MSRV 1.56][msrv-1.56] |
 | [Threefish] | [`threefish`] | [![crates.io](https://img.shields.io/crates/v/threefish.svg)](https://crates.io/crates/threefish) | [![Documentation](https://docs.rs/threefish/badge.svg)](https://docs.rs/threefish) | ![MSRV 1.56][msrv-1.56] |
 | [Twofish] | [`twofish`] | [![crates.io](https://img.shields.io/crates/v/twofish.svg)](https://crates.io/crates/twofish) | [![Documentation](https://docs.rs/twofish/badge.svg)](https://docs.rs/twofish) | ![MSRV 1.56][msrv-1.56] |
@@ -94,6 +95,7 @@ dual licensed as above, without any additional terms or conditions.
 [`kuznyechik`]: ./kuznyechik
 [`magma`]: ./magma
 [`rc2`]: ./rc2
+[`rc5`]: ./rc5
 [`serpent`]: ./serpent
 [`sm4`]: ./sm4
 [`threefish`]: ./threefish
@@ -117,6 +119,7 @@ dual licensed as above, without any additional terms or conditions.
 [Kuznyechik]: https://en.wikipedia.org/wiki/Kuznyechik
 [Magma]: https://en.wikipedia.org/wiki/GOST_(block_cipher)
 [RC2]: https://en.wikipedia.org/wiki/RC2
+[RC5]: https://en.wikipedia.org/wiki/RC5
 [Serpent]: https://en.wikipedia.org/wiki/Serpent_(cipher)
 [SM4]: https://en.wikipedia.org/wiki/SM4_(cipher)
 [Threefish]: https://en.wikipedia.org/wiki/Threefish

--- a/rc5/CHANGELOG.md
+++ b/rc5/CHANGELOG.md
@@ -4,5 +4,3 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## 0.1.0 (2022-11-23)

--- a/rc5/Cargo.toml
+++ b/rc5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc5"
-version = "0.1.0"
+version = "0.0.0"
 description = "RC5 block cipher"
 authors = ["RustCrypto Developers"]
 edition = "2021"

--- a/rc5/README.md
+++ b/rc5/README.md
@@ -1,14 +1,14 @@
-# RustCrypto: RC5 Cipher
+# [RustCrypto]: RC5 Cipher
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 [![HAZMAT][hazmat-image]][hazmat-link]
 
-Pure Rust implementation of the [RC5 block cipher][1].
+Pure Rust implementation of the [RC5] block cipher.
 
 [Documentation][docs-link]
 
@@ -57,15 +57,16 @@ dual licensed as above, without any additional terms or conditions.
 [crate-link]: https://crates.io/crates/rc5
 [docs-image]: https://docs.rs/rc5/badge.svg
 [docs-link]: https://docs.rs/rc5/
+[build-image]: https://github.com/RustCrypto/block-ciphers/actions/workflows/rc5.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-ciphers/actions/workflows/rc5.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260039-block-ciphers
-[build-image]: https://github.com/RustCrypto/block-ciphers/workflows/rc5/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-ciphers/actions?query=workflow%3Arc5
 
 [//]: # (general links)
 
-[1]: https://en.wikipedia.org/wiki/RC5
+[RustCrypto]: https://github.com/RustCrypto/
+[RC5]: https://en.wikipedia.org/wiki/RC5


### PR DESCRIPTION
- Add `rc5` to README.md table
- Bump version down to 0.0.0
- Remove unreleased entry from CHANGELOG.md
- Alphebetize Cargo.toml workspace members