### PR TITLE
aes: refactor ARMv8 `expand_key`

### DIFF
--- a/aes/src/armv8.rs
+++ b/aes/src/armv8.rs
@@ -149,7 +149,7 @@ macro_rules! define_aes_impl {
         impl KeyInit for $name_enc {
             fn new(key: &Key<Self>) -> Self {
                 Self {
-                    round_keys: expand_key(key.as_ref()),
+                    round_keys: unsafe { expand_key(key.as_ref()) },
                 }
             }
         }

--- a/aes/src/armv8/test_expand.rs
+++ b/aes/src/armv8/test_expand.rs
@@ -106,7 +106,7 @@ fn store_expanded_keys<const N: usize>(input: [uint8x16_t; N]) -> [[u8; 16]; N] 
 
 #[test]
 fn aes128_key_expansion() {
-    let ek = expand_key(&AES128_KEY);
+    let ek = unsafe { expand_key(&AES128_KEY) };
     assert_eq!(store_expanded_keys(ek), AES128_EXP_KEYS);
 }
 
@@ -119,12 +119,12 @@ fn aes128_key_expansion_inv() {
 
 #[test]
 fn aes192_key_expansion() {
-    let ek = expand_key(&AES192_KEY);
+    let ek = unsafe { expand_key(&AES192_KEY) };
     assert_eq!(store_expanded_keys(ek), AES192_EXP_KEYS);
 }
 
 #[test]
 fn aes256_key_expansion() {
-    let ek = expand_key(&AES256_KEY);
+    let ek = unsafe { expand_key(&AES256_KEY) };
     assert_eq!(store_expanded_keys(ek), AES256_EXP_KEYS);
 }


### PR DESCRIPTION
Changes `expand_key` to an `unsafe fn` that uses `target_feature`.

Removes the TODOs: due to AES-192 this function can't be easily refactored to use `vinterpretq_u8_u32`.