### PR TITLE
Release kuznyechik v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "cipher",
  "hex-literal",

--- a/kuznyechik/CHANGELOG.md
+++ b/kuznyechik/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.2 (2023-08-06)
+### Fixed
+- `Drop` implementations in the software backend with enabled `zeroize` feature ([#311])
+
+[#311]: https://github.com/RustCrypto/block-ciphers/pull/311
+
 ## 0.8.1 (2022-02-17)
 ### Fixed
 - Minimal versions build ([#303])

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuznyechik"
-version = "0.8.1"
+version = "0.8.2"
 description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Fixed
- `Drop` implementations in the software backend with enabled `zeroize` feature ([#311])

[#311]: https://github.com/RustCrypto/block-ciphers/pull/311