### PR TITLE
bump hex-literal for kuznyechik to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "hex-literal",
+ "hex-literal 0.3.4",
  "zeroize",
 ]
 
@@ -18,7 +18,7 @@ name = "aria"
 version = "0.1.0"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.3.4",
 ]
 
 [[package]]
@@ -26,7 +26,7 @@ name = "belt-block"
 version = "0.1.2"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.3.4",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ name = "cast5"
 version = "0.11.1"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.3.4",
 ]
 
 [[package]]
@@ -126,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "idea"
 version = "0.5.1"
 dependencies = [
@@ -146,7 +152,7 @@ name = "kuznyechik"
 version = "0.8.2"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
@@ -160,7 +166,7 @@ name = "magma"
 version = "0.9.0"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.3.4",
 ]
 
 [[package]]
@@ -190,7 +196,7 @@ name = "sm4"
 version = "0.5.1"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.3.4",
 ]
 
 [[package]]
@@ -198,7 +204,7 @@ name = "speck"
 version = "0.0.1"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.3.4",
 ]
 
 [[package]]
@@ -206,7 +212,7 @@ name = "threefish"
 version = "0.5.2"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.3.4",
  "zeroize",
 ]
 
@@ -215,7 +221,7 @@ name = "twofish"
 version = "0.7.1"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.3.4",
 ]
 
 [[package]]

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -17,7 +17,7 @@ cipher = "0.4.2"
 
 [dev-dependencies]
 cipher = { version = "0.4.2", features = ["dev"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4"
 
 [features]
 zeroize = ["cipher/zeroize"]


### PR DESCRIPTION
ref: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/kuznyechik/debian/patches/relax-deps.patch