### PR TITLE
aes: add #[inline] attributes for KeyInit::new impls

### DIFF
--- a/aes/src/armv8.rs
+++ b/aes/src/armv8.rs
@@ -147,6 +147,7 @@ macro_rules! define_aes_impl {
         }
 
         impl KeyInit for $name_enc {
+            #[inline]
             fn new(key: &Key<Self>) -> Self {
                 Self {
                     round_keys: unsafe { expand_key(key.as_ref()) },
@@ -208,6 +209,7 @@ macro_rules! define_aes_impl {
         }
 
         impl KeyInit for $name_dec {
+            #[inline]
             fn new(key: &Key<Self>) -> Self {
                 $name_enc::new(key).into()
             }

--- a/aes/src/ni.rs
+++ b/aes/src/ni.rs
@@ -157,6 +157,7 @@ macro_rules! define_aes_impl {
         }
 
         impl KeyInit for $name_enc {
+            #[inline]
             fn new(key: &Key<Self>) -> Self {
                 // SAFETY: we enforce that this code is called only when
                 // target features required by `expand` were properly checked.
@@ -220,6 +221,7 @@ macro_rules! define_aes_impl {
         }
 
         impl KeyInit for $name_dec {
+            #[inline]
             fn new(key: &Key<Self>) -> Self {
                 $name_enc::new(key).into()
             }


### PR DESCRIPTION
Fixes #385

