### PR TITLE
Bump `cipher` to v0.5.0-pre.1; MSRV 1.65

### DIFF
--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -73,7 +73,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -81,7 +81,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -104,7 +104,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -112,7 +112,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -137,7 +137,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -145,7 +145,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -167,13 +167,13 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
     runs-on: ubuntu-latest
@@ -217,7 +217,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            rust: 1.61.0 # MSRV for `aes_armv8`
+            rust: 1.65.0 # MSRV
     runs-on: ubuntu-latest
     # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
     defaults:
@@ -245,6 +245,6 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.56.0 # MSRV
+          toolchain: 1.65.0 # MSRV
           components: clippy
       - run: cargo clippy --features hazmat -- -D warnings

--- a/.github/workflows/aria.yml
+++ b/.github/workflows/aria.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/belt-block.yml
+++ b/.github/workflows/belt-block.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/blowfish.yml
+++ b/.github/workflows/blowfish.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/camellia.yml
+++ b/.github/workflows/camellia.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cast5.yml
+++ b/.github/workflows/cast5.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cast6.yml
+++ b/.github/workflows/cast6.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/des.yml
+++ b/.github/workflows/des.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/idea.yml
+++ b/.github/workflows/idea.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/kuznyechik.yml
+++ b/.github/workflows/kuznyechik.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/magma.yml
+++ b/.github/workflows/magma.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rc2.yml
+++ b/.github/workflows/rc2.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rc5.yml
+++ b/.github/workflows/rc5.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/serpent.yml
+++ b/.github/workflows/serpent.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sm4.yml
+++ b/.github/workflows/sm4.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/speck.yml
+++ b/.github/workflows/speck.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/threefish.yml
+++ b/.github/workflows/threefish.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/twofish.yml
+++ b/.github/workflows/twofish.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cipher"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#ea9f8a3ded8137ce3d8729b165bc4d413cc52486"
+source = "git+https://github.com/RustCrypto/traits.git#6810dc1dcfe9949f2f2e8e6f3e077737b97c06f1"
 dependencies = [
  "blobby",
  "crypto-common",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47bf010313404f942f7da6931d00bd455bb4c36c36c9d4dd9497b5ac316f6fe1"
+checksum = "102f7900795d54e3b8566857762a2977c267ab5952e4117283017ee1d5c9ae88"
 dependencies = [
  "hybrid-array",
 ]
@@ -129,9 +129,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-pre.6"
+version = "0.2.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f148d5add3c53ebf18452f556b0437d3d5c4540f34eb7b80c5ad4b54632c4e2"
+checksum = "c23513baf3d4dec43f51f0d5793d9f3058d909040a0130f86c53c4a340fcad05"
 dependencies = [
  "typenum",
 ]
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed415a0622334b6e89f6361616b133f5ca2a8a31c5007ca594d9180e5930ec8"
+checksum = "25049cbfd794227f26a7d3c7f2cfc2a9737a229993799bfca1138242964886ee"
 dependencies = [
  "hybrid-array",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,8 +81,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#6810dc1dcfe9949f2f2e8e6f3e077737b97c06f1"
+version = "0.5.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e338a2ceb7493b9b89d12728c6feb2d4b61708cb63b577c556c92f43aef0cd"
 dependencies = [
  "blobby",
  "crypto-common",
@@ -101,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.2"
+version = "0.2.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102f7900795d54e3b8566857762a2977c267ab5952e4117283017ee1d5c9ae88"
+checksum = "cc17eb697364b18256ec92675ebe6b7b153d2f1041e568d74533c5d0fc1ca162"
 dependencies = [
  "hybrid-array",
 ]
@@ -129,9 +130,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-pre.7"
+version = "0.2.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c23513baf3d4dec43f51f0d5793d9f3058d909040a0130f86c53c4a340fcad05"
+checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
 dependencies = [
  "typenum",
 ]
@@ -145,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-pre.2"
+version = "0.2.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25049cbfd794227f26a7d3c7f2cfc2a9737a229993799bfca1138242964886ee"
+checksum = "96ea9986e1fde8d177cd039f00f9f316d3bfce9ebc2787c1267d4414adf3acb3"
 dependencies = [
  "hybrid-array",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,29 +4,29 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.9.0-pre"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "hex-literal",
+ "hex-literal 0.3.4",
  "zeroize",
 ]
 
 [[package]]
 name = "aria"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
 name = "belt-block"
-version = "0.1.2"
+version = "0.2.0-pre"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "blowfish"
-version = "0.9.1"
+version = "0.10.0-pre"
 dependencies = [
  "byteorder",
  "cipher",
@@ -51,7 +51,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "camellia"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "byteorder",
  "cipher",
@@ -59,18 +59,18 @@ dependencies = [
 
 [[package]]
 name = "cast5"
-version = "0.11.1"
+version = "0.12.0-pre"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
 name = "cast6"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
@@ -81,9 +81,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+version = "0.5.0-pre"
+source = "git+https://github.com/RustCrypto/traits.git#ea9f8a3ded8137ce3d8729b165bc4d413cc52486"
 dependencies = [
  "blobby",
  "crypto-common",
@@ -102,29 +101,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "47bf010313404f942f7da6931d00bd455bb4c36c36c9d4dd9497b5ac316f6fe1"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "des"
-version = "0.8.1"
+version = "0.9.0-pre"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -134,27 +122,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f148d5add3c53ebf18452f556b0437d3d5c4540f34eb7b80c5ad4b54632c4e2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "idea"
-version = "0.5.1"
+version = "0.6.0-pre"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.2.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "eed415a0622334b6e89f6361616b133f5ca2a8a31c5007ca594d9180e5930ec8"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "kuznyechik"
-version = "0.8.2"
+version = "0.9.0-pre"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
@@ -165,15 +168,15 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "magma"
-version = "0.9.0"
+version = "0.10.0-pre"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
 name = "rc2"
-version = "0.8.1"
+version = "0.9.0-pre"
 dependencies = [
  "cipher",
 ]
@@ -187,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "serpent"
-version = "0.5.1"
+version = "0.6.0-pre"
 dependencies = [
  "byteorder",
  "cipher",
@@ -195,35 +198,35 @@ dependencies = [
 
 [[package]]
 name = "sm4"
-version = "0.5.1"
+version = "0.6.0-pre"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
-name = "speck"
-version = "0.0.1"
+name = "speck-cipher"
+version = "0.0.0"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
 name = "threefish"
-version = "0.5.2"
+version = "0.6.0-pre"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
  "zeroize",
 ]
 
 [[package]]
 name = "twofish"
-version = "0.7.1"
+version = "0.8.0-pre"
 dependencies = [
  "cipher",
- "hex-literal",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
@@ -233,13 +236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "aes",
     "aria",
@@ -22,3 +23,6 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+cipher = { git = "https://github.com/RustCrypto/traits.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-cipher = { git = "https://github.com/RustCrypto/traits.git" }

--- a/README.md
+++ b/README.md
@@ -36,24 +36,24 @@ It's generally recommended not to use other cipher implementations in this repos
 
 | Name | Crate name | crates.io | Docs | MSRV |
 |------|------------|-----------|------|------|
-| [AES] (Rijndael) | [`aes`] | [![crates.io](https://img.shields.io/crates/v/aes.svg)](https://crates.io/crates/aes) | [![Documentation](https://docs.rs/aes/badge.svg)](https://docs.rs/aes) | ![MSRV 1.56][msrv-1.56] |
-| [ARIA] | [`aria`] | [![crates.io](https://img.shields.io/crates/v/aria.svg)](https://crates.io/crates/aria) | [![Documentation](https://docs.rs/aria/badge.svg)](https://docs.rs/aria) | ![MSRV 1.56][msrv-1.56] |
-| [BelT] block cipher | [`belt-block`] | [![crates.io](https://img.shields.io/crates/v/belt-block.svg)](https://crates.io/crates/belt-block) | [![Documentation](https://docs.rs/belt-block/badge.svg)](https://docs.rs/belt-block) | ![MSRV 1.56][msrv-1.56] |
-| [Blowfish] | [`blowfish`] | [![crates.io](https://img.shields.io/crates/v/blowfish.svg)](https://crates.io/crates/blowfish) | [![Documentation](https://docs.rs/blowfish/badge.svg)](https://docs.rs/blowfish) | ![MSRV 1.56][msrv-1.56] |
-| [Camellia] | [`camellia`] | [![crates.io](https://img.shields.io/crates/v/camellia.svg)](https://crates.io/crates/camellia) | [![Documentation](https://docs.rs/camellia/badge.svg)](https://docs.rs/camellia) | ![MSRV 1.56][msrv-1.56] |
-| [CAST5] (CAST-128) | [`cast5`] | [![crates.io](https://img.shields.io/crates/v/cast5.svg)](https://crates.io/crates/cast5) | [![Documentation](https://docs.rs/cast5/badge.svg)](https://docs.rs/cast5) | ![MSRV 1.56][msrv-1.56] |
-| [CAST6] (CAST-256) | [`cast6`] | [![crates.io](https://img.shields.io/crates/v/cast6.svg)](https://crates.io/crates/cast6) | [![Documentation](https://docs.rs/cast6/badge.svg)](https://docs.rs/cast6) | ![MSRV 1.56][msrv-1.56] |
-| [DES] + [3DES] (DEA, 3DEA) | [`des`] | [![crates.io](https://img.shields.io/crates/v/des.svg)](https://crates.io/crates/des) | [![Documentation](https://docs.rs/des/badge.svg)](https://docs.rs/des) | ![MSRV 1.56][msrv-1.56] |
-| [IDEA] | [`idea`] | [![crates.io](https://img.shields.io/crates/v/idea.svg)](https://crates.io/crates/idea) | [![Documentation](https://docs.rs/idea/badge.svg)](https://docs.rs/idea) | ![MSRV 1.56][msrv-1.56] |
-| [Kuznyechik] (GOST R 34.12-2015)  | [`kuznyechik`] | [![crates.io](https://img.shields.io/crates/v/kuznyechik.svg)](https://crates.io/crates/kuznyechik) | [![Documentation](https://docs.rs/kuznyechik/badge.svg)](https://docs.rs/kuznyechik) | ![MSRV 1.56][msrv-1.56] |
-| [Magma] (GOST R 34.12-2015) | [`magma`] | [![crates.io](https://img.shields.io/crates/v/magma.svg)](https://crates.io/crates/magma) | [![Documentation](https://docs.rs/magma/badge.svg)](https://docs.rs/magma) | ![MSRV 1.56][msrv-1.56] |
-| [RC2] (ARC2) | [`rc2`] | [![crates.io](https://img.shields.io/crates/v/rc2.svg)](https://crates.io/crates/rc2) | [![Documentation](https://docs.rs/rc2/badge.svg)](https://docs.rs/rc2) | ![MSRV 1.56][msrv-1.56] |
-| [RC5] | [`rc5`] | [![crates.io](https://img.shields.io/crates/v/rc5.svg)](https://crates.io/crates/rc5) | [![Documentation](https://docs.rs/rc5/badge.svg)](https://docs.rs/rc5) | ![MSRV 1.56][msrv-1.56] |
-| [Serpent] | [`serpent`] | [![crates.io](https://img.shields.io/crates/v/serpent.svg)](https://crates.io/crates/serpent) | [![Documentation](https://docs.rs/serpent/badge.svg)](https://docs.rs/serpent) | ![MSRV 1.56][msrv-1.56] |
-| [SM4] | [`sm4`] | [![crates.io](https://img.shields.io/crates/v/sm4.svg)](https://crates.io/crates/sm4) | [![Documentation](https://docs.rs/sm4/badge.svg)](https://docs.rs/sm4) | ![MSRV 1.56][msrv-1.56] |
-| [Speck] | `speck` | [![crates.io](https://img.shields.io/crates/v/speck.svg)](https://crates.io/crates/speck) | [![Documentation](https://docs.rs/speck/badge.svg)](https://docs.rs/speck) | ![MSRV 1.56][msrv-1.56] |
-| [Threefish] | [`threefish`] | [![crates.io](https://img.shields.io/crates/v/threefish.svg)](https://crates.io/crates/threefish) | [![Documentation](https://docs.rs/threefish/badge.svg)](https://docs.rs/threefish) | ![MSRV 1.56][msrv-1.56] |
-| [Twofish] | [`twofish`] | [![crates.io](https://img.shields.io/crates/v/twofish.svg)](https://crates.io/crates/twofish) | [![Documentation](https://docs.rs/twofish/badge.svg)](https://docs.rs/twofish) | ![MSRV 1.56][msrv-1.56] |
+| [AES] (Rijndael) | [`aes`] | [![crates.io](https://img.shields.io/crates/v/aes.svg)](https://crates.io/crates/aes) | [![Documentation](https://docs.rs/aes/badge.svg)](https://docs.rs/aes) | ![MSRV 1.65][msrv-1.65] |
+| [ARIA] | [`aria`] | [![crates.io](https://img.shields.io/crates/v/aria.svg)](https://crates.io/crates/aria) | [![Documentation](https://docs.rs/aria/badge.svg)](https://docs.rs/aria) | ![MSRV 1.65][msrv-1.65] |
+| [BelT] block cipher | [`belt-block`] | [![crates.io](https://img.shields.io/crates/v/belt-block.svg)](https://crates.io/crates/belt-block) | [![Documentation](https://docs.rs/belt-block/badge.svg)](https://docs.rs/belt-block) | ![MSRV 1.65][msrv-1.65] |
+| [Blowfish] | [`blowfish`] | [![crates.io](https://img.shields.io/crates/v/blowfish.svg)](https://crates.io/crates/blowfish) | [![Documentation](https://docs.rs/blowfish/badge.svg)](https://docs.rs/blowfish) | ![MSRV 1.65][msrv-1.65] |
+| [Camellia] | [`camellia`] | [![crates.io](https://img.shields.io/crates/v/camellia.svg)](https://crates.io/crates/camellia) | [![Documentation](https://docs.rs/camellia/badge.svg)](https://docs.rs/camellia) | ![MSRV 1.65][msrv-1.65] |
+| [CAST5] (CAST-128) | [`cast5`] | [![crates.io](https://img.shields.io/crates/v/cast5.svg)](https://crates.io/crates/cast5) | [![Documentation](https://docs.rs/cast5/badge.svg)](https://docs.rs/cast5) | ![MSRV 1.65][msrv-1.65] |
+| [CAST6] (CAST-256) | [`cast6`] | [![crates.io](https://img.shields.io/crates/v/cast6.svg)](https://crates.io/crates/cast6) | [![Documentation](https://docs.rs/cast6/badge.svg)](https://docs.rs/cast6) | ![MSRV 1.65][msrv-1.65] |
+| [DES] + [3DES] (DEA, 3DEA) | [`des`] | [![crates.io](https://img.shields.io/crates/v/des.svg)](https://crates.io/crates/des) | [![Documentation](https://docs.rs/des/badge.svg)](https://docs.rs/des) | ![MSRV 1.65][msrv-1.65] |
+| [IDEA] | [`idea`] | [![crates.io](https://img.shields.io/crates/v/idea.svg)](https://crates.io/crates/idea) | [![Documentation](https://docs.rs/idea/badge.svg)](https://docs.rs/idea) | ![MSRV 1.65][msrv-1.65] |
+| [Kuznyechik] (GOST R 34.12-2015)  | [`kuznyechik`] | [![crates.io](https://img.shields.io/crates/v/kuznyechik.svg)](https://crates.io/crates/kuznyechik) | [![Documentation](https://docs.rs/kuznyechik/badge.svg)](https://docs.rs/kuznyechik) | ![MSRV 1.65][msrv-1.65] |
+| [Magma] (GOST R 34.12-2015) | [`magma`] | [![crates.io](https://img.shields.io/crates/v/magma.svg)](https://crates.io/crates/magma) | [![Documentation](https://docs.rs/magma/badge.svg)](https://docs.rs/magma) | ![MSRV 1.65][msrv-1.65] |
+| [RC2] (ARC2) | [`rc2`] | [![crates.io](https://img.shields.io/crates/v/rc2.svg)](https://crates.io/crates/rc2) | [![Documentation](https://docs.rs/rc2/badge.svg)](https://docs.rs/rc2) | ![MSRV 1.65][msrv-1.65] |
+| [RC5] | [`rc5`] | [![crates.io](https://img.shields.io/crates/v/rc5.svg)](https://crates.io/crates/rc5) | [![Documentation](https://docs.rs/rc5/badge.svg)](https://docs.rs/rc5) | ![MSRV 1.65][msrv-1.65] |
+| [Serpent] | [`serpent`] | [![crates.io](https://img.shields.io/crates/v/serpent.svg)](https://crates.io/crates/serpent) | [![Documentation](https://docs.rs/serpent/badge.svg)](https://docs.rs/serpent) | ![MSRV 1.65][msrv-1.65] |
+| [SM4] | [`sm4`] | [![crates.io](https://img.shields.io/crates/v/sm4.svg)](https://crates.io/crates/sm4) | [![Documentation](https://docs.rs/sm4/badge.svg)](https://docs.rs/sm4) | ![MSRV 1.65][msrv-1.65] |
+| [Speck] | `speck` | [![crates.io](https://img.shields.io/crates/v/speck.svg)](https://crates.io/crates/speck) | [![Documentation](https://docs.rs/speck/badge.svg)](https://docs.rs/speck) | ![MSRV 1.65][msrv-1.65] |
+| [Threefish] | [`threefish`] | [![crates.io](https://img.shields.io/crates/v/threefish.svg)](https://crates.io/crates/threefish) | [![Documentation](https://docs.rs/threefish/badge.svg)](https://docs.rs/threefish) | ![MSRV 1.65][msrv-1.65] |
+| [Twofish] | [`twofish`] | [![crates.io](https://img.shields.io/crates/v/twofish.svg)](https://crates.io/crates/twofish) | [![Documentation](https://docs.rs/twofish/badge.svg)](https://docs.rs/twofish) | ![MSRV 1.65][msrv-1.65] |
 
 ### Minimum Supported Rust Version (MSRV) Policy
 
@@ -83,7 +83,7 @@ dual licensed as above, without any additional terms or conditions.
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
-[msrv-1.56]: https://img.shields.io/badge/rustc-1.56.0+-blue.svg
+[msrv-1.65]: https://img.shields.io/badge/rustc-1.65.0+-blue.svg
 
 [//]: # (crates)
 

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "aes"
-version = "0.8.3"
+version = "0.9.0-pre"
 description = "Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/aes"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -14,20 +14,14 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
+zeroize = { version = "1.5.6", optional = true, default_features = false, features = ["aarch64"] }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
 
-[target.'cfg(not(all(aes_armv8, target_arch = "aarch64")))'.dependencies]
-zeroize = { version = "1.6.0", optional = true, default_features = false }
-
-# TODO(tarcieri): unconditionally enable `aarch64` feature when MSRV is 1.59
-[target.'cfg(all(aes_armv8, target_arch = "aarch64"))'.dependencies]
-zeroize = { version = "1.5.6", optional = true, default_features = false, features = ["aarch64"] }
-
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
 hex-literal = "0.3"
 
 [features]

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -14,14 +14,14 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 zeroize = { version = "1.5.6", optional = true, default_features = false, features = ["aarch64"] }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.3"
 
 [features]

--- a/aes/README.md
+++ b/aes/README.md
@@ -43,7 +43,7 @@ using a portable implementation based on bitslicing.
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in future releases, but it will
 be done with a minor version bump.
@@ -75,7 +75,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aes/badge.svg
 [docs-link]: https://docs.rs/aes/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260039-block-ciphers
 [build-image]: https://github.com/RustCrypto/block-ciphers/workflows/aes/badge.svg?branch=master&event=push

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -55,11 +55,11 @@
 //! use aes::Aes128;
 //! use aes::cipher::{
 //!     BlockCipher, BlockEncrypt, BlockDecrypt, KeyInit,
-//!     generic_array::GenericArray,
+//!     array::Array,
 //! };
 //!
-//! let key = GenericArray::from([0u8; 16]);
-//! let mut block = GenericArray::from([42u8; 16]);
+//! let key = Array::from([0u8; 16]);
+//! let mut block = Array::from([42u8; 16]);
 //!
 //! // Initialize cipher
 //! let cipher = Aes128::new(&key);
@@ -150,13 +150,13 @@ cfg_if! {
 pub use cipher;
 use cipher::{
     consts::{U16, U8},
-    generic_array::GenericArray,
+    array::Array,
 };
 
 /// 128-bit AES block
-pub type Block = GenericArray<u8, U16>;
+pub type Block = Array<u8, U16>;
 /// Eight 128-bit AES blocks
-pub type Block8 = GenericArray<Block, U8>;
+pub type Block8 = Array<Block, U8>;
 
 #[cfg(test)]
 mod tests {

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -149,8 +149,8 @@ cfg_if! {
 
 pub use cipher;
 use cipher::{
-    consts::{U16, U8},
     array::Array,
+    consts::{U16, U8},
 };
 
 /// 128-bit AES block

--- a/aes/src/soft.rs
+++ b/aes/src/soft.rs
@@ -63,7 +63,7 @@ macro_rules! define_aes_impl {
             #[inline]
             fn new(key: &Key<Self>) -> Self {
                 Self {
-                    keys: $fixslice_key_schedule(key.as_ref()),
+                    keys: $fixslice_key_schedule(key.into()),
                 }
             }
         }

--- a/aes/src/soft/fixslice32.rs
+++ b/aes/src/soft/fixslice32.rs
@@ -16,12 +16,12 @@
 #![allow(clippy::unreadable_literal)]
 
 use crate::Block;
-use cipher::{consts::U2, generic_array::GenericArray};
+use cipher::{consts::U2, array::Array};
 
 /// AES block batch size for this implementation
 pub(crate) type FixsliceBlocks = U2;
 
-pub(crate) type BatchBlocks = GenericArray<Block, FixsliceBlocks>;
+pub(crate) type BatchBlocks = Array<Block, FixsliceBlocks>;
 
 /// AES-128 round keys
 pub(crate) type FixsliceKeys128 = [u32; 88];

--- a/aes/src/soft/fixslice32.rs
+++ b/aes/src/soft/fixslice32.rs
@@ -16,7 +16,7 @@
 #![allow(clippy::unreadable_literal)]
 
 use crate::Block;
-use cipher::{consts::U2, array::Array};
+use cipher::{array::Array, consts::U2};
 
 /// AES block batch size for this implementation
 pub(crate) type FixsliceBlocks = U2;

--- a/aes/src/soft/fixslice64.rs
+++ b/aes/src/soft/fixslice64.rs
@@ -16,7 +16,7 @@
 #![allow(clippy::unreadable_literal)]
 
 use crate::Block;
-use cipher::{consts::U4, array::Array};
+use cipher::{array::Array, consts::U4};
 
 /// AES block batch size for this implementation
 pub(crate) type FixsliceBlocks = U4;

--- a/aes/src/soft/fixslice64.rs
+++ b/aes/src/soft/fixslice64.rs
@@ -16,12 +16,12 @@
 #![allow(clippy::unreadable_literal)]
 
 use crate::Block;
-use cipher::{consts::U4, generic_array::GenericArray};
+use cipher::{consts::U4, array::Array};
 
 /// AES block batch size for this implementation
 pub(crate) type FixsliceBlocks = U4;
 
-pub(crate) type BatchBlocks = GenericArray<Block, FixsliceBlocks>;
+pub(crate) type BatchBlocks = Array<Block, FixsliceBlocks>;
 
 /// AES-128 round keys
 pub(crate) type FixsliceKeys128 = [u64; 88];

--- a/aria/Cargo.toml
+++ b/aria/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "aria", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/aria/Cargo.toml
+++ b/aria/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "aria"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = "Pure Rust implementation of the ARIA Encryption Algorithm"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/aria"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "aria", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
-hex-literal = "0.3"
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/aria/README.md
+++ b/aria/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aria/badge.svg
 [docs-link]: https://docs.rs/aria/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/aria/src/lib.rs
+++ b/aria/src/lib.rs
@@ -10,12 +10,12 @@
 //!
 //! # Examples
 //! ```
-//! use aria::cipher::generic_array::GenericArray;
+//! use aria::cipher::array::Array;
 //! use aria::cipher::{Key, Block, BlockEncrypt, BlockDecrypt, KeyInit};
 //! use aria::Aria128;
 //!
-//! let key = GenericArray::from([0u8; 16]);
-//! let mut block = GenericArray::from([0u8; 16]);
+//! let key = Array::from([0u8; 16]);
+//! let mut block = Array::from([0u8; 16]);
 //! // Initialize cipher
 //! let cipher = Aria128::new(&key);
 //!

--- a/aria/tests/mod.rs
+++ b/aria/tests/mod.rs
@@ -1,5 +1,5 @@
 use aria::{Aria128, Aria192, Aria256};
-use cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{array::Array, BlockDecrypt, BlockEncrypt, KeyInit};
 use hex_literal::hex;
 
 /// Test vector from RFC 5794, Appendix A.1
@@ -11,11 +11,11 @@ fn test_rfc5794_a1() {
 
     let c = Aria128::new_from_slice(&key).unwrap();
 
-    let mut buf = GenericArray::from(pt);
+    let mut buf = Array::from(pt);
     c.encrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), ct);
+    assert_eq!(buf.as_ref(), &ct);
     c.decrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), pt);
+    assert_eq!(buf.as_ref(), &pt);
 }
 
 /// Test vector from RFC 5794, Appendix A.2
@@ -27,11 +27,11 @@ fn test_rfc5794_a2() {
 
     let c = Aria192::new_from_slice(&key).unwrap();
 
-    let mut buf = GenericArray::from(pt);
+    let mut buf = Array::from(pt);
     c.encrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), ct);
+    assert_eq!(buf.as_ref(), &ct);
     c.decrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), pt);
+    assert_eq!(buf.as_ref(), &pt);
 }
 
 /// Test vector from RFC 5794, Appendix A.3
@@ -43,9 +43,9 @@ fn test_rfc5794_a3() {
 
     let c = Aria256::new_from_slice(&key).unwrap();
 
-    let mut buf = GenericArray::from(pt);
+    let mut buf = Array::from(pt);
     c.encrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), ct);
+    assert_eq!(buf.as_ref(), &ct);
     c.decrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), pt);
+    assert_eq!(buf.as_ref(), &pt);
 }

--- a/aria/tests/mod.rs
+++ b/aria/tests/mod.rs
@@ -13,9 +13,9 @@ fn test_rfc5794_a1() {
 
     let mut buf = Array::from(pt);
     c.encrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), &ct);
+    assert_eq!(&buf, &ct);
     c.decrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), &pt);
+    assert_eq!(&buf, &pt);
 }
 
 /// Test vector from RFC 5794, Appendix A.2
@@ -29,9 +29,9 @@ fn test_rfc5794_a2() {
 
     let mut buf = Array::from(pt);
     c.encrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), &ct);
+    assert_eq!(&buf, &ct);
     c.decrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), &pt);
+    assert_eq!(&buf, &pt);
 }
 
 /// Test vector from RFC 5794, Appendix A.3
@@ -45,7 +45,7 @@ fn test_rfc5794_a3() {
 
     let mut buf = Array::from(pt);
     c.encrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), &ct);
+    assert_eq!(&buf, &ct);
     c.decrypt_block(&mut buf);
-    assert_eq!(buf.as_ref(), &pt);
+    assert_eq!(&buf, &pt);
 }

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "belt-block", "belt", "stb"]
 
 [dependencies]
-cipher = { version = "=0.5.0-pre", optional = true }
+cipher = { version = "=0.5.0-pre.1", optional = true }
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "belt-block"
-version = "0.1.2"
+version = "0.2.0-pre"
 description = "belt-block block cipher implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-rust-version = "1.56"
+rust-version = "1.65"
 edition = "2021"
 readme = "README.md"
 documentation = "https://docs.rs/belt-block"
@@ -12,11 +12,11 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "belt-block", "belt", "stb"]
 
 [dependencies]
-cipher = { version = "0.4.3", optional = true }
+cipher = { version = "=0.5.0-pre", optional = true }
 
 [dev-dependencies]
-cipher = { version = "0.4.3", features = ["dev"] }
-hex-literal = "0.3.4"
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["cipher"]

--- a/belt-block/README.md
+++ b/belt-block/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/belt-block/badge.svg
 [docs-link]: https://docs.rs/belt-block/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/belt-block/tests/mod.rs
+++ b/belt-block/tests/mod.rs
@@ -34,9 +34,9 @@ fn belt_block() {
             let cipher = BeltBlock::new(&key.into());
             let mut block = pt.into();
             cipher.encrypt_block(&mut block);
-            assert_eq!(block, ct.into());
+            assert_eq!(block, ct);
             cipher.decrypt_block(&mut block);
-            assert_eq!(block, pt.into());
+            assert_eq!(block, pt);
         }
     }
 }

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "blowfish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 byteorder = { version = "1.1", default-features = false }
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 
 [features]
 bcrypt = []

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blowfish"
-version = "0.9.1"
+version = "0.10.0-pre"
 description = "Blowfish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ keywords = ["crypto", "blowfish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 byteorder = { version = "1.1", default-features = false }
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
 
 [features]
 bcrypt = []

--- a/blowfish/README.md
+++ b/blowfish/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/blowfish/badge.svg
 [docs-link]: https://docs.rs/blowfish/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/camellia/Cargo.toml
+++ b/camellia/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1.1", default-features = false }
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/camellia/Cargo.toml
+++ b/camellia/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "camellia"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = "Camellia block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/camellia"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1.1", default-features = false }
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/camellia/README.md
+++ b/camellia/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/camellia/badge.svg
 [docs-link]: https://docs.rs/camellia/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/camellia/src/lib.rs
+++ b/camellia/src/lib.rs
@@ -10,12 +10,12 @@
 //!
 //! # Examples
 //! ```
-//! use camellia::cipher::generic_array::GenericArray;
+//! use camellia::cipher::array::Array;
 //! use camellia::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 //! use camellia::Camellia128;
 //!
-//! let key = GenericArray::from([0_u8; 16]);
-//! let mut block = GenericArray::from([0_u8; 16]);
+//! let key = Array::from([0_u8; 16]);
+//! let mut block = Array::from([0_u8; 16]);
 //!
 //! // Initialize cipher
 //! let cipher = Camellia128::new(&key);

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "cast5"
-version = "0.11.1"
+version = "0.12.0-pre"
 description = "CAST5 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/cast5"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "cast5", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
-hex-literal = "0.3"
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast5", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/cast5/README.md
+++ b/cast5/README.md
@@ -28,7 +28,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -60,7 +60,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/cast5/badge.svg
 [docs-link]: https://docs.rs/cast5/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/cast5/src/lib.rs
+++ b/cast5/src/lib.rs
@@ -10,12 +10,12 @@
 //!
 //! # Examples
 //! ```
-//! use cast5::cipher::generic_array::GenericArray;
+//! use cast5::cipher::array::Array;
 //! use cast5::cipher::{Key, Block, BlockEncrypt, BlockDecrypt, KeyInit};
 //! use cast5::Cast5;
 //!
-//! let key = GenericArray::from([0u8; 16]);
-//! let mut block = GenericArray::from([0u8; 8]);
+//! let key = Array::from([0u8; 16]);
+//! let mut block = Array::from([0u8; 8]);
 //! // Initialize cipher
 //! let cipher = Cast5::new(&key);
 //!

--- a/cast5/tests/mod.rs
+++ b/cast5/tests/mod.rs
@@ -1,5 +1,5 @@
 use cast5::Cast5;
-use cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{array::Array, BlockDecrypt, BlockEncrypt, KeyInit};
 use hex_literal::hex;
 
 /// Test vectors from RFC 2144 Appendix B.1
@@ -9,10 +9,10 @@ fn rfc2144_b1() {
     let key128 = hex!("0123456712345678234567893456789A");
     let key80 = hex!("01234567123456782345");
     let key40 = hex!("0123456712");
-    let ct128 = GenericArray::from(hex!("238B4FE5847E44B2"));
-    let ct80 = GenericArray::from(hex!("EB6A711A2C02271B"));
-    let ct40 = GenericArray::from(hex!("7AC816D16E9B302E"));
-    let pt = GenericArray::from(hex!("0123456789ABCDEF"));
+    let ct128 = Array::from(hex!("238B4FE5847E44B2"));
+    let ct80 = Array::from(hex!("EB6A711A2C02271B"));
+    let ct40 = Array::from(hex!("7AC816D16E9B302E"));
+    let pt = Array::from(hex!("0123456789ABCDEF"));
 
     let mut buf = pt;
 
@@ -50,14 +50,14 @@ fn full_maintance_test() {
     let (al, ar) = a.split_at_mut(8);
     let (bl, br) = b.split_at_mut(8);
 
-    let al = GenericArray::from_mut_slice(al);
-    let ar = GenericArray::from_mut_slice(ar);
+    let al = Array::from_mut_slice(al);
+    let ar = Array::from_mut_slice(ar);
 
-    let bl = GenericArray::from_mut_slice(bl);
-    let br = GenericArray::from_mut_slice(br);
+    let bl = Array::from_mut_slice(bl);
+    let br = Array::from_mut_slice(br);
 
     for _ in 0..count {
-        let mut k = GenericArray::from([0u8; 16]);
+        let mut k = Array::from([0u8; 16]);
         k[..8].copy_from_slice(bl);
         k[8..].copy_from_slice(br);
         let c = Cast5::new(&k);

--- a/cast5/tests/mod.rs
+++ b/cast5/tests/mod.rs
@@ -39,36 +39,36 @@ fn rfc2144_b1() {
 /// https://tools.ietf.org/html/rfc2144#appendix-B.1
 #[test]
 fn full_maintance_test() {
-    let mut a = hex!("0123456712345678234567893456789A");
-    let mut b = hex!("0123456712345678234567893456789A");
+    let a = hex!("0123456712345678234567893456789A");
+    let b = hex!("0123456712345678234567893456789A");
 
     let verify_a = hex!("EEA9D0A249FD3BA6B3436FB89D6DCA92");
     let verify_b = hex!("B2C95EB00C31AD7180AC05B8E83D696E");
 
     let count = 1_000_000;
 
-    let (al, ar) = a.split_at_mut(8);
-    let (bl, br) = b.split_at_mut(8);
+    let (al, ar) = a.split_at(8);
+    let (bl, br) = b.split_at(8);
 
-    let al = Array::from_mut_slice(al);
-    let ar = Array::from_mut_slice(ar);
+    let mut al = Array::try_from(al).unwrap();
+    let mut ar = Array::try_from(ar).unwrap();
 
-    let bl = Array::from_mut_slice(bl);
-    let br = Array::from_mut_slice(br);
+    let mut bl = Array::try_from(bl).unwrap();
+    let mut br = Array::try_from(br).unwrap();
 
     for _ in 0..count {
         let mut k = Array::from([0u8; 16]);
-        k[..8].copy_from_slice(bl);
-        k[8..].copy_from_slice(br);
+        k[..8].copy_from_slice(&bl);
+        k[8..].copy_from_slice(&br);
         let c = Cast5::new(&k);
-        c.encrypt_block(al);
-        c.encrypt_block(ar);
+        c.encrypt_block(&mut al);
+        c.encrypt_block(&mut ar);
 
-        k[..8].copy_from_slice(al);
-        k[8..].copy_from_slice(ar);
+        k[..8].copy_from_slice(&al);
+        k[8..].copy_from_slice(&ar);
         let c = Cast5::new(&k);
-        c.encrypt_block(bl);
-        c.encrypt_block(br);
+        c.encrypt_block(&mut bl);
+        c.encrypt_block(&mut br);
     }
 
     assert_eq!(&al[..], &verify_a[..8]);

--- a/cast6/Cargo.toml
+++ b/cast6/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast6", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/cast6/Cargo.toml
+++ b/cast6/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "cast6"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = "CAST6 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/cast6"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "cast6", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.3"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.3", features = ["dev"] }
-hex-literal = "0.3"
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/cast6/README.md
+++ b/cast6/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/cast6/badge.svg
 [docs-link]: https://docs.rs/cast6/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/cast6/src/lib.rs
+++ b/cast6/src/lib.rs
@@ -10,12 +10,12 @@
 //!
 //! # Examples
 //! ```
-//! use cast6::cipher::generic_array::GenericArray;
+//! use cast6::cipher::array::Array;
 //! use cast6::cipher::{Key, Block, BlockEncrypt, BlockDecrypt, KeyInit};
 //! use cast6::Cast6;
 //!
-//! let key = GenericArray::from([0u8; 32]);
-//! let mut block = GenericArray::from([0u8; 16]);
+//! let key = Array::from([0u8; 32]);
+//! let mut block = Array::from([0u8; 16]);
 //! // Initialize cipher
 //! let cipher = Cast6::new(&key);
 //!

--- a/cast6/tests/mod.rs
+++ b/cast6/tests/mod.rs
@@ -9,9 +9,9 @@ fn rfc2144_a() {
     let key128 = hex!("2342bb9efa38542c0af75647f29f615d");
     let key192 = hex!("2342bb9efa38542cbed0ac83940ac298bac77a7717942863");
     let key256 = hex!("2342bb9efa38542cbed0ac83940ac2988d7c47ce264908461cc1b5137ae6b604");
-    let ct128 = hex!("c842a08972b43d20836c91d1b7530f6b").into();
-    let ct192 = hex!("1b386c0210dcadcbdd0e41aa08a7a7e8").into();
-    let ct256 = hex!("4f6a2038286897b9c9870136553317fa").into();
+    let ct128 = hex!("c842a08972b43d20836c91d1b7530f6b");
+    let ct192 = hex!("1b386c0210dcadcbdd0e41aa08a7a7e8");
+    let ct256 = hex!("4f6a2038286897b9c9870136553317fa");
     let pt = Block::<Cast6>::default();
 
     let mut buf = pt;

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "des", "tdes", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "des"
-version = "0.8.1"
+version = "0.9.0-pre"
 description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/des"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,10 +13,10 @@ keywords = ["crypto", "des", "tdes", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/des/README.md
+++ b/des/README.md
@@ -28,7 +28,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -60,7 +60,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/des/badge.svg
 [docs-link]: https://docs.rs/des/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "idea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "idea"
-version = "0.5.1"
+version = "0.6.0-pre"
 description = "IDEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/idea"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,10 +13,10 @@ keywords = ["crypto", "idea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/idea/README.md
+++ b/idea/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/idea/badge.svg
 [docs-link]: https://docs.rs/idea/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "kuznyechik", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "kuznyechik"
-version = "0.8.2"
+version = "0.9.0-pre"
 description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/kuznyechik"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "kuznyechik", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
-hex-literal = "0.3.3"
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/kuznyechik/README.md
+++ b/kuznyechik/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/kuznyechik/badge.svg
 [docs-link]: https://docs.rs/kuznyechik/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/kuznyechik/src/lib.rs
+++ b/kuznyechik/src/lib.rs
@@ -32,7 +32,7 @@
 pub use cipher;
 use cipher::{
     consts::{U16, U32},
-    generic_array::GenericArray,
+    array::Array,
 };
 
 mod consts;
@@ -59,6 +59,6 @@ type BlockSize = U16;
 type KeySize = U32;
 
 /// 128-bit Kuznyechik block
-pub type Block = GenericArray<u8, U16>;
+pub type Block = Array<u8, U16>;
 /// 256-bit Kuznyechik key
-pub type Key = GenericArray<u8, U32>;
+pub type Key = Array<u8, U32>;

--- a/kuznyechik/src/lib.rs
+++ b/kuznyechik/src/lib.rs
@@ -31,8 +31,8 @@
 
 pub use cipher;
 use cipher::{
-    consts::{U16, U32},
     array::Array,
+    consts::{U16, U32},
 };
 
 mod consts;

--- a/kuznyechik/src/soft/mod.rs
+++ b/kuznyechik/src/soft/mod.rs
@@ -47,9 +47,7 @@ impl From<KuznyechikEnc> for Kuznyechik {
 impl From<&KuznyechikEnc> for Kuznyechik {
     #[inline]
     fn from(enc: &KuznyechikEnc) -> Kuznyechik {
-        Self {
-            keys: enc.keys.clone(),
-        }
+        Self { keys: enc.keys }
     }
 }
 
@@ -177,9 +175,7 @@ impl From<KuznyechikEnc> for KuznyechikDec {
 impl From<&KuznyechikEnc> for KuznyechikDec {
     #[inline]
     fn from(enc: &KuznyechikEnc) -> KuznyechikDec {
-        Self {
-            keys: enc.keys.clone(),
-        }
+        Self { keys: enc.keys }
     }
 }
 

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "magma"
-version = "0.9.0"
+version = "0.10.0-pre"
 description = "Magma (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/magma"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "magma", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
-hex-literal = "0.3.3"
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "magma", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/magma/README.md
+++ b/magma/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/magma/badge.svg
 [docs-link]: https://docs.rs/magma/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/magma/src/lib.rs
+++ b/magma/src/lib.rs
@@ -13,7 +13,7 @@
 //! ```
 //! use magma::Magma;
 //! use magma::cipher::{
-//!     generic_array::GenericArray,
+//!     array::Array,
 //!     BlockEncrypt, BlockDecrypt, KeyInit,
 //! };
 //! use hex_literal::hex;
@@ -28,7 +28,7 @@
 //!
 //! let cipher = Magma::new(&key.into());
 //!
-//! let mut block = GenericArray::clone_from_slice(&plaintext);
+//! let mut block = Array::clone_from_slice(&plaintext);
 //! cipher.encrypt_block(&mut block);
 //! assert_eq!(&ciphertext, block.as_slice());
 //!

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "rc2", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rc2"
-version = "0.8.1"
+version = "0.9.0-pre"
 description = "RC2 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/rc2"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,10 +13,10 @@ keywords = ["crypto", "rc2", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/rc2/README.md
+++ b/rc2/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/rc2/badge.svg
 [docs-link]: https://docs.rs/rc2/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/rc2/tests/mod.rs
+++ b/rc2/tests/mod.rs
@@ -1,4 +1,4 @@
-use cipher::generic_array::GenericArray;
+use cipher::array::Array;
 use cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 
 struct Test {
@@ -26,11 +26,11 @@ fn rc2() {
     for test in &tests {
         let cipher = rc2::Rc2::new_from_slice(test.key).unwrap();
 
-        let mut buf = GenericArray::clone_from_slice(test.input);
+        let mut buf = Array::clone_from_slice(test.input);
         cipher.encrypt_block(&mut buf);
         assert_eq!(test.output, &buf[..]);
 
-        let mut buf = GenericArray::clone_from_slice(test.output);
+        let mut buf = Array::clone_from_slice(test.output);
         cipher.decrypt_block(&mut buf);
         assert_eq!(test.input, &buf[..]);
     }
@@ -42,11 +42,11 @@ fn rc2_effective_key_64() {
     for test in &tests {
         let cipher = rc2::Rc2::new_with_eff_key_len(test.key, 64);
 
-        let mut buf = GenericArray::clone_from_slice(test.input);
+        let mut buf = Array::clone_from_slice(test.input);
         cipher.encrypt_block(&mut buf);
         assert_eq!(test.output, &buf[..]);
 
-        let mut buf = GenericArray::clone_from_slice(test.output);
+        let mut buf = Array::clone_from_slice(test.output);
         cipher.decrypt_block(&mut buf);
         assert_eq!(test.input, &buf[..]);
     }
@@ -58,11 +58,11 @@ fn rc2_effective_key_129() {
     for test in &tests {
         let cipher = rc2::Rc2::new_with_eff_key_len(test.key, 129);
 
-        let mut buf = GenericArray::clone_from_slice(test.input);
+        let mut buf = Array::clone_from_slice(test.input);
         cipher.encrypt_block(&mut buf);
         assert_eq!(test.output, &buf[..]);
 
-        let mut buf = GenericArray::clone_from_slice(test.output);
+        let mut buf = Array::clone_from_slice(test.output);
         cipher.decrypt_block(&mut buf);
         assert_eq!(test.input, &buf[..]);
     }

--- a/rc5/Cargo.toml
+++ b/rc5/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["crypto", "rc5", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = { version = "=0.5.0-pre", features = ["zeroize"] }
+cipher = { version = "=0.5.0-pre.1", features = ["zeroize"] }
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 
 [features]
 zeroize = []

--- a/rc5/Cargo.toml
+++ b/rc5/Cargo.toml
@@ -5,17 +5,17 @@ description = "RC5 block cipher"
 authors = ["RustCrypto Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "rc5", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = { version = "0.4.3", features = ["zeroize"] }
+cipher = { version = "=0.5.0-pre", features = ["zeroize"] }
 
 [dev-dependencies]
-cipher = { version = "0.4.3", features = ["dev"] }
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
 
 [features]
 zeroize = []

--- a/rc5/README.md
+++ b/rc5/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -60,7 +60,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/block-ciphers/actions/workflows/rc5.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/block-ciphers/actions/workflows/rc5.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/rc5/src/block_cipher.rs
+++ b/rc5/src/block_cipher.rs
@@ -1,8 +1,9 @@
 use core::ops::{Add, Div, Mul, Sub};
 
 use cipher::{
+    array::ArraySize,
     consts::*,
-    generic_array::ArrayLength,
+    crypto_common::BlockSizes,
     inout::InOut,
     typenum::{Diff, IsLess, Le, NonZero, Sum, Unsigned, U1, U2, U256},
     AlgorithmName, Block, BlockBackend, BlockCipher, BlockDecrypt, BlockEncrypt, BlockSizeUser,
@@ -16,7 +17,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -24,16 +25,16 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
     // Key range
-    B: ArrayLength<u8>,
+    B: ArraySize,
     B: IsLess<U256>,
     Le<B, U256>: NonZero,
     // KeyAsWordsSize
     B: Add<W::Bytes>,
     Sum<B, W::Bytes>: Sub<U1>,
     Diff<Sum<B, W::Bytes>, U1>: Div<W::Bytes>,
-    KeyAsWordsSize<W, B>: ArrayLength<W>,
+    KeyAsWordsSize<W, B>: ArraySize,
 {
     fn new(key: &cipher::Key<Self>) -> Self {
         Self::new(key)
@@ -45,7 +46,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -53,8 +54,8 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
-    B: ArrayLength<u8>,
+    ExpandedKeyTableSize<R>: ArraySize,
+    B: ArraySize,
 {
     type KeySize = B;
 }
@@ -64,7 +65,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -72,7 +73,7 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
 {
 }
 
@@ -81,7 +82,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -89,7 +90,7 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
 {
     type BlockSize = BlockSize<W>;
 }
@@ -99,7 +100,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -107,16 +108,16 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
     // Key range
-    B: ArrayLength<u8>,
+    B: ArraySize,
     B: IsLess<U256>,
     Le<B, U256>: NonZero,
     // KeyAsWordsSize
     B: Add<W::Bytes>,
     Sum<B, W::Bytes>: Sub<U1>,
     Diff<Sum<B, W::Bytes>, U1>: Div<W::Bytes>,
-    KeyAsWordsSize<W, B>: ArrayLength<W>,
+    KeyAsWordsSize<W, B>: ArraySize,
 {
     fn encrypt_with_backend(&self, f: impl cipher::BlockClosure<BlockSize = Self::BlockSize>) {
         f.call(&mut RC5EncryptBackend { enc_dec: self })
@@ -128,7 +129,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -136,7 +137,7 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
 {
     enc_dec: &'a RC5<W, R, B>,
 }
@@ -145,7 +146,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -153,7 +154,7 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
 {
     type BlockSize = BlockSize<W>;
 }
@@ -163,7 +164,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -171,7 +172,7 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
 {
     type ParBlocksSize = U1;
 }
@@ -181,7 +182,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -189,16 +190,16 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
     // Key range
-    B: ArrayLength<u8>,
+    B: ArraySize,
     B: IsLess<U256>,
     Le<B, U256>: NonZero,
     // KeyAsWordsSize
     B: Add<W::Bytes>,
     Sum<B, W::Bytes>: Sub<U1>,
     Diff<Sum<B, W::Bytes>, U1>: Div<W::Bytes>,
-    KeyAsWordsSize<W, B>: ArrayLength<W>,
+    KeyAsWordsSize<W, B>: ArraySize,
 {
     #[inline(always)]
     fn proc_block(&mut self, block: InOut<'_, '_, Block<Self>>) {
@@ -212,7 +213,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -220,16 +221,16 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
     // Key range
-    B: ArrayLength<u8>,
+    B: ArraySize,
     B: IsLess<U256>,
     Le<B, U256>: NonZero,
     // KeyAsWordsSize
     B: Add<W::Bytes>,
     Sum<B, W::Bytes>: Sub<U1>,
     Diff<Sum<B, W::Bytes>, U1>: Div<W::Bytes>,
-    KeyAsWordsSize<W, B>: ArrayLength<W>,
+    KeyAsWordsSize<W, B>: ArraySize,
 {
     fn decrypt_with_backend(&self, f: impl cipher::BlockClosure<BlockSize = Self::BlockSize>) {
         f.call(&mut RC5DecryptBackend { enc_dec: self })
@@ -241,7 +242,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -249,7 +250,7 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
 {
     enc_dec: &'a RC5<W, R, B>,
 }
@@ -258,7 +259,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -266,7 +267,7 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
 {
     type BlockSize = BlockSize<W>;
 }
@@ -276,7 +277,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -284,7 +285,7 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
 {
     type ParBlocksSize = U1;
 }
@@ -294,7 +295,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -302,16 +303,16 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
     // Key range
-    B: ArrayLength<u8>,
+    B: ArraySize,
     B: IsLess<U256>,
     Le<B, U256>: NonZero,
     // KeyAsWordsSize
     B: Add<W::Bytes>,
     Sum<B, W::Bytes>: Sub<U1>,
     Diff<Sum<B, W::Bytes>, U1>: Div<W::Bytes>,
-    KeyAsWordsSize<W, B>: ArrayLength<W>,
+    KeyAsWordsSize<W, B>: ArraySize,
 {
     #[inline(always)]
     fn proc_block(&mut self, block: InOut<'_, '_, Block<Self>>) {
@@ -325,7 +326,7 @@ where
     W: Word,
     // Block size
     W::Bytes: Mul<U2>,
-    BlockSize<W>: ArrayLength<u8>,
+    BlockSize<W>: BlockSizes,
     // Rounds range
     R: Unsigned,
     R: IsLess<U256>,
@@ -333,7 +334,7 @@ where
     // ExpandedKeyTableSize
     R: Add<U1>,
     Sum<R, U1>: Mul<U2>,
-    ExpandedKeyTableSize<R>: ArrayLength<W>,
+    ExpandedKeyTableSize<R>: ArraySize,
 {
     fn write_alg_name(f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(

--- a/rc5/src/core/primitives.rs
+++ b/rc5/src/core/primitives.rs
@@ -1,26 +1,26 @@
 use core::ops::{Add, BitXor};
 
 use cipher::{
-    generic_array::{ArrayLength, GenericArray},
+    array::{ArraySize, Array},
     typenum::{Diff, Prod, Quot, Sum, U1, U16, U2, U4, U8},
     zeroize::DefaultIsZeroes,
 };
 
 pub type BlockSize<W> = Prod<<W as Word>::Bytes, U2>;
-pub type Block<W> = GenericArray<u8, BlockSize<W>>;
+pub type Block<W> = Array<u8, BlockSize<W>>;
 
-pub type Key<B> = GenericArray<u8, B>;
+pub type Key<B> = Array<u8, B>;
 
-pub type ExpandedKeyTable<W, R> = GenericArray<W, ExpandedKeyTableSize<R>>;
+pub type ExpandedKeyTable<W, R> = Array<W, ExpandedKeyTableSize<R>>;
 pub type ExpandedKeyTableSize<R> = Prod<Sum<R, U1>, U2>;
 
-pub type KeyAsWords<W, B> = GenericArray<W, KeyAsWordsSize<W, B>>;
+pub type KeyAsWords<W, B> = Array<W, KeyAsWordsSize<W, B>>;
 pub type KeyAsWordsSize<W, B> = Quot<Diff<Sum<B, <W as Word>::Bytes>, U1>, <W as Word>::Bytes>;
 
 pub trait Word:
     Default + Copy + From<u8> + Add<Output = Self> + DefaultIsZeroes + Default + private::Sealed
 {
-    type Bytes: ArrayLength<u8>;
+    type Bytes: ArraySize;
 
     const ZERO: Self;
     const THREE: Self;
@@ -35,8 +35,8 @@ pub trait Word:
     fn rotate_left(self, n: Self) -> Self;
     fn rotate_right(self, n: Self) -> Self;
 
-    fn from_le_bytes(bytes: &GenericArray<u8, Self::Bytes>) -> Self;
-    fn to_le_bytes(self) -> GenericArray<u8, Self::Bytes>;
+    fn from_le_bytes(bytes: &Array<u8, Self::Bytes>) -> Self;
+    fn to_le_bytes(self) -> Array<u8, Self::Bytes>;
 
     fn bitxor(self, other: Self) -> Self;
 }
@@ -80,12 +80,12 @@ impl Word for u8 {
     }
 
     #[inline(always)]
-    fn from_le_bytes(bytes: &GenericArray<u8, Self::Bytes>) -> Self {
+    fn from_le_bytes(bytes: &Array<u8, Self::Bytes>) -> Self {
         u8::from_le_bytes(bytes.as_slice().try_into().unwrap())
     }
 
     #[inline(always)]
-    fn to_le_bytes(self) -> GenericArray<u8, Self::Bytes> {
+    fn to_le_bytes(self) -> Array<u8, Self::Bytes> {
         u8::to_le_bytes(self).into()
     }
 
@@ -125,12 +125,12 @@ impl Word for u16 {
     }
 
     #[inline(always)]
-    fn from_le_bytes(bytes: &GenericArray<u8, Self::Bytes>) -> Self {
+    fn from_le_bytes(bytes: &Array<u8, Self::Bytes>) -> Self {
         u16::from_le_bytes(bytes.as_slice().try_into().unwrap())
     }
 
     #[inline(always)]
-    fn to_le_bytes(self) -> GenericArray<u8, Self::Bytes> {
+    fn to_le_bytes(self) -> Array<u8, Self::Bytes> {
         u16::to_le_bytes(self).into()
     }
 
@@ -170,12 +170,12 @@ impl Word for u32 {
     }
 
     #[inline(always)]
-    fn from_le_bytes(bytes: &GenericArray<u8, Self::Bytes>) -> Self {
+    fn from_le_bytes(bytes: &Array<u8, Self::Bytes>) -> Self {
         u32::from_le_bytes(bytes.as_slice().try_into().unwrap())
     }
 
     #[inline(always)]
-    fn to_le_bytes(self) -> GenericArray<u8, Self::Bytes> {
+    fn to_le_bytes(self) -> Array<u8, Self::Bytes> {
         u32::to_le_bytes(self).into()
     }
 
@@ -217,12 +217,12 @@ impl Word for u64 {
     }
 
     #[inline(always)]
-    fn from_le_bytes(bytes: &GenericArray<u8, Self::Bytes>) -> Self {
+    fn from_le_bytes(bytes: &Array<u8, Self::Bytes>) -> Self {
         u64::from_le_bytes(bytes.as_slice().try_into().unwrap())
     }
 
     #[inline(always)]
-    fn to_le_bytes(self) -> GenericArray<u8, Self::Bytes> {
+    fn to_le_bytes(self) -> Array<u8, Self::Bytes> {
         u64::to_le_bytes(self).into()
     }
 
@@ -264,12 +264,12 @@ impl Word for u128 {
     }
 
     #[inline(always)]
-    fn from_le_bytes(bytes: &GenericArray<u8, Self::Bytes>) -> Self {
+    fn from_le_bytes(bytes: &Array<u8, Self::Bytes>) -> Self {
         u128::from_le_bytes(bytes.as_slice().try_into().unwrap())
     }
 
     #[inline(always)]
-    fn to_le_bytes(self) -> GenericArray<u8, Self::Bytes> {
+    fn to_le_bytes(self) -> Array<u8, Self::Bytes> {
         u128::to_le_bytes(self).into()
     }
 

--- a/rc5/src/core/primitives.rs
+++ b/rc5/src/core/primitives.rs
@@ -1,7 +1,7 @@
 use core::ops::{Add, BitXor};
 
 use cipher::{
-    array::{ArraySize, Array},
+    array::{Array, ArraySize},
     typenum::{Diff, Prod, Quot, Sum, U1, U16, U2, U4, U8},
     zeroize::DefaultIsZeroes,
 };

--- a/rc5/tests/mod.rs
+++ b/rc5/tests/mod.rs
@@ -2,7 +2,7 @@
 #[cfg(test)]
 mod tests {
     use cipher::consts::*;
-    use cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
+    use cipher::{array::Array, BlockDecrypt, BlockEncrypt, KeyInit};
     use rc5::RC5;
 
     #[test]
@@ -14,7 +14,7 @@ mod tests {
 
         let rc5 = <RC5<u8, U12, U4> as KeyInit>::new_from_slice(&key).unwrap();
 
-        let mut block = GenericArray::clone_from_slice(&pt);
+        let mut block = Array::clone_from_slice(&pt);
         rc5.encrypt_block(&mut block);
 
         assert_eq!(ct, block[..]);
@@ -32,7 +32,7 @@ mod tests {
 
         let rc5 = <RC5<u16, U16, U8> as KeyInit>::new_from_slice(&key).unwrap();
 
-        let mut block = GenericArray::clone_from_slice(&pt);
+        let mut block = Array::clone_from_slice(&pt);
         rc5.encrypt_block(&mut block);
 
         assert_eq!(ct, block[..]);
@@ -53,7 +53,7 @@ mod tests {
 
         let rc5 = <RC5<u32, U12, U16> as KeyInit>::new_from_slice(&key).unwrap();
 
-        let mut block = GenericArray::clone_from_slice(&pt);
+        let mut block = Array::clone_from_slice(&pt);
         rc5.encrypt_block(&mut block);
 
         assert_eq!(ct, block[..]);
@@ -74,7 +74,7 @@ mod tests {
 
         let rc5 = <RC5<u32, U16, U16> as KeyInit>::new_from_slice(&key).unwrap();
 
-        let mut block = GenericArray::clone_from_slice(&pt);
+        let mut block = Array::clone_from_slice(&pt);
         rc5.encrypt_block(&mut block);
 
         assert_eq!(ct, block[..]);
@@ -101,7 +101,7 @@ mod tests {
 
         let rc5 = <RC5<u64, U24, U24> as KeyInit>::new_from_slice(&key).unwrap();
 
-        let mut block = GenericArray::clone_from_slice(&pt);
+        let mut block = Array::clone_from_slice(&pt);
         rc5.encrypt_block(&mut block);
 
         assert_eq!(ct, block[..]);
@@ -131,7 +131,7 @@ mod tests {
 
         let rc5 = <RC5<u128, U28, U32> as KeyInit>::new_from_slice(&key).unwrap();
 
-        let mut block = GenericArray::clone_from_slice(&pt);
+        let mut block = Array::clone_from_slice(&pt);
         rc5.encrypt_block(&mut block);
 
         assert_eq!(ct, block[..]);

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "serpent"
-version = "0.5.1"
+version = "0.6.0-pre"
 description = "Serpent block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/serpent"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1.1", default-features = false }
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1.1", default-features = false }
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/serpent/README.md
+++ b/serpent/README.md
@@ -28,7 +28,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -60,7 +60,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/serpent/badge.svg
 [docs-link]: https://docs.rs/serpent/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sm4"
-version = "0.5.1"
+version = "0.6.0-pre"
 description = "SM4 block cipher algorithm"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/sm4"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "sm4", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
-hex-literal = "0.3"
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "sm4", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/sm4/README.md
+++ b/sm4/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sm4/badge.svg
 [docs-link]: https://docs.rs/sm4/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/speck/Cargo.toml
+++ b/speck/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["crypto", "speck", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.4"

--- a/speck/Cargo.toml
+++ b/speck/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "speck"
-version = "0.0.1" # Also update html_root_url in lib.rs when bumping this
+name = "speck-cipher"
+version = "0.0.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Speck block cipher algorithm"
@@ -8,13 +8,13 @@ documentation = "https://docs.rs/speck"
 repository = "https://github.com/RustCrypto/block-ciphers/tree/master/speck"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 keywords = ["crypto", "speck", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
-hex-literal = "0.3"
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
+hex-literal = "0.4"

--- a/speck/README.md
+++ b/speck/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/speck/README.md
+++ b/speck/README.md
@@ -53,12 +53,12 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/speck.svg
-[crate-link]: https://crates.io/crates/speck
-[docs-image]: https://docs.rs/speck/badge.svg
-[docs-link]: https://docs.rs/speck/
+[crate-image]: https://img.shields.io/crates/v/speck-cipher.svg
+[crate-link]: https://crates.io/crates/speck-cipher
+[docs-image]: https://docs.rs/speck-cipher/badge.svg
+[docs-link]: https://docs.rs/speck-cipher/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/speck/tests/mod.rs
+++ b/speck/tests/mod.rs
@@ -2,7 +2,7 @@
 
 use cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 use hex_literal::hex;
-use speck::{
+use speck_cipher::{
     Speck128_128, Speck128_192, Speck128_256, Speck32_64, Speck48_72, Speck48_96, Speck64_128,
     Speck64_96, Speck96_144, Speck96_96,
 };

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "threefish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = { version = "=0.5.0-pre", optional = true }
+cipher = { version = "=0.5.0-pre.1", optional = true }
 zeroize = { version = "1.6", optional = true, default-features = false }
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"]}
+cipher = { version = "=0.5.0-pre.1", features = ["dev"]}
 hex-literal = "0.4"
 
 [features]

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "threefish"
-version = "0.5.2"
+version = "0.6.0-pre"
 description = "Threefish block cipher"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/threefish"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,12 +13,12 @@ keywords = ["crypto", "threefish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = { version = "0.4.2", optional = true }
+cipher = { version = "=0.5.0-pre", optional = true }
 zeroize = { version = "1.6", optional = true, default-features = false }
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"]}
-hex-literal = "0.3.3"
+cipher = { version = "=0.5.0-pre", features = ["dev"]}
+hex-literal = "0.4"
 
 [features]
 default = ["cipher"]

--- a/threefish/README.md
+++ b/threefish/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/threefish/badge.svg
 [docs-link]: https://docs.rs/threefish/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "twofish"
-version = "0.7.1"
+version = "0.8.0-pre"
 description = "Twofish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/twofish"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "twofish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.2"
+cipher = "=0.5.0-pre"
 
 [dev-dependencies]
-cipher = { version = "0.4.2", features = ["dev"] }
-hex-literal = "0.3"
+cipher = { version = "=0.5.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "twofish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/twofish/README.md
+++ b/twofish/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/twofish/badge.svg
 [docs-link]: https://docs.rs/twofish/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/twofish/tests/mod.rs
+++ b/twofish/tests/mod.rs
@@ -1,4 +1,4 @@
-use cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{array::Array, BlockDecrypt, BlockEncrypt, KeyInit};
 use hex_literal::hex;
 use twofish::Twofish;
 
@@ -11,7 +11,7 @@ macro_rules! new_test {
         #[test]
         fn $name() {
             let mut key = [0u8; $key_len];
-            let mut plain = GenericArray::default();
+            let mut plain = Array::default();
             let mut cipher;
 
             for i in 1..50 {


### PR DESCRIPTION
The main notable change is the replacement of `generic-array` with `hybrid-array`, which brings with it an MSRV of 1.65.