### PR TITLE
Use `BlockCipherEncrypt`/`BlockCipherDecrypt` trait names

### DIFF
--- a/.github/workflows/speck.yml
+++ b/.github/workflows/speck.yml
@@ -36,6 +36,7 @@ jobs:
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
   minimal-versions:
+    if: false # TODO: temp disabled due to unpublished prerelease dependencies
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,8 +82,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cipher"
 version = "0.5.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40619e61d2e7c018604193e71763730a96b0e606e19aba895956635986c7fe98"
+source = "git+https://github.com/RustCrypto/traits.git#4459f6012afda093816e6a592828a57a8fc366ed"
 dependencies = [
  "blobby",
  "crypto-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io.cipher]
+git = "https://github.com/RustCrypto/traits.git"

--- a/aes/src/armv8.rs
+++ b/aes/src/armv8.rs
@@ -25,7 +25,7 @@ use crate::{Block, Block8};
 use cipher::{
     consts::{U16, U24, U32, U8},
     inout::InOut,
-    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt,
+    AlgorithmName, BlockBackend, BlockCipher, BlockCipherDecrypt, BlockCipherEncrypt, BlockClosure,
     BlockSizeUser, Key, KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 use core::arch::aarch64::*;

--- a/aes/src/armv8.rs
+++ b/aes/src/armv8.rs
@@ -25,7 +25,7 @@ use crate::{Block, Block8};
 use cipher::{
     consts::{U16, U24, U32, U8},
     inout::InOut,
-    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt,
+    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt,
     BlockSizeUser, Key, KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 use core::arch::aarch64::*;
@@ -98,13 +98,13 @@ macro_rules! define_aes_impl {
             type BlockSize = U16;
         }
 
-        impl BlockEncrypt for $name {
+        impl BlockCipherEncrypt for $name {
             fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 self.encrypt.encrypt_with_backend(f)
             }
         }
 
-        impl BlockDecrypt for $name {
+        impl BlockCipherDecrypt for $name {
             fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 self.decrypt.decrypt_with_backend(f)
             }
@@ -158,7 +158,7 @@ macro_rules! define_aes_impl {
             type BlockSize = U16;
         }
 
-        impl BlockEncrypt for $name_enc {
+        impl BlockCipherEncrypt for $name_enc {
             fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 f.call(&mut self.get_enc_backend())
             }
@@ -233,7 +233,7 @@ macro_rules! define_aes_impl {
             type BlockSize = U16;
         }
 
-        impl BlockDecrypt for $name_dec {
+        impl BlockCipherDecrypt for $name_dec {
             fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 f.call(&mut self.get_dec_backend());
             }

--- a/aes/src/autodetect.rs
+++ b/aes/src/autodetect.rs
@@ -4,8 +4,8 @@
 use crate::soft;
 use cipher::{
     consts::{U16, U24, U32},
-    AlgorithmName, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser, Key,
-    KeyInit, KeySizeUser,
+    AlgorithmName, BlockCipher, BlockCipherDecrypt, BlockCipherEncrypt, BlockClosure,
+    BlockSizeUser, Key, KeyInit, KeySizeUser,
 };
 use core::fmt;
 use core::mem::ManuallyDrop;

--- a/aes/src/autodetect.rs
+++ b/aes/src/autodetect.rs
@@ -4,7 +4,7 @@
 use crate::soft;
 use cipher::{
     consts::{U16, U24, U32},
-    AlgorithmName, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, Key,
+    AlgorithmName, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser, Key,
     KeyInit, KeySizeUser,
 };
 use core::fmt;
@@ -130,7 +130,7 @@ macro_rules! define_aes_impl {
 
         impl BlockCipher for $name {}
 
-        impl BlockEncrypt for $name {
+        impl BlockCipherEncrypt for $name {
             fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 unsafe {
                     if self.token.get() {
@@ -149,7 +149,7 @@ macro_rules! define_aes_impl {
             }
         }
 
-        impl BlockDecrypt for $name {
+        impl BlockCipherDecrypt for $name {
             fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 unsafe {
                     if self.token.get() {
@@ -249,7 +249,7 @@ macro_rules! define_aes_impl {
 
         impl BlockCipher for $name_enc {}
 
-        impl BlockEncrypt for $name_enc {
+        impl BlockCipherEncrypt for $name_enc {
             fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 unsafe {
                     if self.token.get() {
@@ -378,7 +378,7 @@ macro_rules! define_aes_impl {
 
         impl BlockCipher for $name_dec {}
 
-        impl BlockDecrypt for $name_dec {
+        impl BlockCipherDecrypt for $name_dec {
             fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 unsafe {
                     if self.token.get() {

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -52,7 +52,7 @@
 //! ```
 //! use aes::Aes128;
 //! use aes::cipher::{
-//!     BlockCipher, BlockEncrypt, BlockDecrypt, KeyInit,
+//!     BlockCipher, BlockCipherEncrypt, BlockCipherDecrypt, KeyInit,
 //!     array::Array,
 //! };
 //!

--- a/aes/src/ni.rs
+++ b/aes/src/ni.rs
@@ -37,7 +37,7 @@ use crate::{Block, Block8};
 use cipher::{
     consts::{U16, U24, U32, U8},
     inout::InOut,
-    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt,
+    AlgorithmName, BlockBackend, BlockCipher, BlockCipherDecrypt, BlockCipherEncrypt, BlockClosure,
     BlockSizeUser, Key, KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 use core::fmt;

--- a/aes/src/ni.rs
+++ b/aes/src/ni.rs
@@ -37,7 +37,7 @@ use crate::{Block, Block8};
 use cipher::{
     consts::{U16, U24, U32, U8},
     inout::InOut,
-    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt,
+    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt,
     BlockSizeUser, Key, KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 use core::fmt;
@@ -109,13 +109,13 @@ macro_rules! define_aes_impl {
             type BlockSize = U16;
         }
 
-        impl BlockEncrypt for $name {
+        impl BlockCipherEncrypt for $name {
             fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 self.encrypt.encrypt_with_backend(f)
             }
         }
 
-        impl BlockDecrypt for $name {
+        impl BlockCipherDecrypt for $name {
             fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 self.decrypt.decrypt_with_backend(f)
             }
@@ -171,7 +171,7 @@ macro_rules! define_aes_impl {
             type BlockSize = U16;
         }
 
-        impl BlockEncrypt for $name_enc {
+        impl BlockCipherEncrypt for $name_enc {
             fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 f.call(&mut self.get_enc_backend())
             }
@@ -246,7 +246,7 @@ macro_rules! define_aes_impl {
             type BlockSize = U16;
         }
 
-        impl BlockDecrypt for $name_dec {
+        impl BlockCipherDecrypt for $name_dec {
             fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 f.call(&mut self.get_dec_backend());
             }

--- a/aes/src/soft.rs
+++ b/aes/src/soft.rs
@@ -16,7 +16,7 @@ use crate::Block;
 use cipher::{
     consts::{U16, U24, U32},
     inout::InOut,
-    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt,
+    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt,
     BlockSizeUser, Key, KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 use core::fmt;
@@ -74,13 +74,13 @@ macro_rules! define_aes_impl {
 
         impl BlockCipher for $name {}
 
-        impl BlockEncrypt for $name {
+        impl BlockCipherEncrypt for $name {
             fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 f.call(&mut self.get_enc_backend())
             }
         }
 
-        impl BlockDecrypt for $name {
+        impl BlockCipherDecrypt for $name {
             fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 f.call(&mut self.get_dec_backend())
             }
@@ -155,7 +155,7 @@ macro_rules! define_aes_impl {
             type BlockSize = U16;
         }
 
-        impl BlockEncrypt for $name_enc {
+        impl BlockCipherEncrypt for $name_enc {
             fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 f.call(&mut self.get_enc_backend())
             }
@@ -224,7 +224,7 @@ macro_rules! define_aes_impl {
             type BlockSize = U16;
         }
 
-        impl BlockDecrypt for $name_dec {
+        impl BlockCipherDecrypt for $name_dec {
             fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = U16>) {
                 f.call(&mut self.get_dec_backend());
             }

--- a/aes/src/soft.rs
+++ b/aes/src/soft.rs
@@ -16,7 +16,7 @@ use crate::Block;
 use cipher::{
     consts::{U16, U24, U32},
     inout::InOut,
-    AlgorithmName, BlockBackend, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt,
+    AlgorithmName, BlockBackend, BlockCipher, BlockCipherDecrypt, BlockCipherEncrypt, BlockClosure,
     BlockSizeUser, Key, KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 use core::fmt;

--- a/aria/src/lib.rs
+++ b/aria/src/lib.rs
@@ -11,7 +11,7 @@
 //! # Examples
 //! ```
 //! use aria::cipher::array::Array;
-//! use aria::cipher::{Key, Block, BlockEncrypt, BlockDecrypt, KeyInit};
+//! use aria::cipher::{Key, Block, BlockCipherEncrypt, BlockCipherDecrypt, KeyInit};
 //! use aria::Aria128;
 //!
 //! let key = Array::from([0u8; 16]);

--- a/aria/tests/mod.rs
+++ b/aria/tests/mod.rs
@@ -1,5 +1,5 @@
 use aria::{Aria128, Aria192, Aria256};
-use cipher::{array::Array, BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{array::Array, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use hex_literal::hex;
 
 /// Test vector from RFC 5794, Appendix A.1

--- a/belt-block/tests/mod.rs
+++ b/belt-block/tests/mod.rs
@@ -3,7 +3,7 @@
 use belt_block::{belt_block_raw, belt_wblock_dec, belt_wblock_enc, to_u32};
 #[cfg(feature = "cipher")]
 use belt_block::{
-    cipher::{BlockDecrypt, BlockEncrypt, KeyInit},
+    cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit},
     BeltBlock,
 };
 use hex_literal::hex;

--- a/camellia/src/lib.rs
+++ b/camellia/src/lib.rs
@@ -11,7 +11,7 @@
 //! # Examples
 //! ```
 //! use camellia::cipher::array::Array;
-//! use camellia::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+//! use camellia::cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 //! use camellia::Camellia128;
 //!
 //! let key = Array::from([0_u8; 16]);

--- a/cast5/src/lib.rs
+++ b/cast5/src/lib.rs
@@ -11,7 +11,7 @@
 //! # Examples
 //! ```
 //! use cast5::cipher::array::Array;
-//! use cast5::cipher::{Key, Block, BlockEncrypt, BlockDecrypt, KeyInit};
+//! use cast5::cipher::{Key, Block, BlockCipherEncrypt, BlockCipherDecrypt, KeyInit};
 //! use cast5::Cast5;
 //!
 //! let key = Array::from([0u8; 16]);

--- a/cast5/tests/mod.rs
+++ b/cast5/tests/mod.rs
@@ -1,5 +1,5 @@
 use cast5::Cast5;
-use cipher::{array::Array, BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{array::Array, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use hex_literal::hex;
 
 /// Test vectors from RFC 2144 Appendix B.1

--- a/cast6/src/lib.rs
+++ b/cast6/src/lib.rs
@@ -11,7 +11,7 @@
 //! # Examples
 //! ```
 //! use cast6::cipher::array::Array;
-//! use cast6::cipher::{Key, Block, BlockEncrypt, BlockDecrypt, KeyInit};
+//! use cast6::cipher::{Key, Block, BlockCipherEncrypt, BlockCipherDecrypt, KeyInit};
 //! use cast6::Cast6;
 //!
 //! let key = Array::from([0u8; 32]);

--- a/cast6/tests/mod.rs
+++ b/cast6/tests/mod.rs
@@ -1,5 +1,5 @@
 use cast6::Cast6;
-use cipher::{Block, BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{Block, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use hex_literal::hex;
 
 /// Test vectors from RFC 2612 Appendix A

--- a/kuznyechik/src/soft/mod.rs
+++ b/kuznyechik/src/soft/mod.rs
@@ -1,7 +1,7 @@
 use crate::{BlockSize, Key, KeySize};
 use cipher::{
-    AlgorithmName, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser, KeyInit,
-    KeySizeUser,
+    AlgorithmName, BlockCipher, BlockCipherDecrypt, BlockCipherEncrypt, BlockClosure,
+    BlockSizeUser, KeyInit, KeySizeUser,
 };
 use core::fmt;
 

--- a/kuznyechik/src/soft/mod.rs
+++ b/kuznyechik/src/soft/mod.rs
@@ -1,6 +1,6 @@
 use crate::{BlockSize, Key, KeySize};
 use cipher::{
-    AlgorithmName, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, KeyInit,
+    AlgorithmName, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser, KeyInit,
     KeySizeUser,
 };
 use core::fmt;
@@ -51,13 +51,13 @@ impl From<&KuznyechikEnc> for Kuznyechik {
     }
 }
 
-impl BlockEncrypt for Kuznyechik {
+impl BlockCipherEncrypt for Kuznyechik {
     fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut EncBackend(&self.keys));
     }
 }
 
-impl BlockDecrypt for Kuznyechik {
+impl BlockCipherDecrypt for Kuznyechik {
     fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut DecBackend(&self.keys));
     }
@@ -111,7 +111,7 @@ impl KeyInit for KuznyechikEnc {
     }
 }
 
-impl BlockEncrypt for KuznyechikEnc {
+impl BlockCipherEncrypt for KuznyechikEnc {
     fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut EncBackend(&self.keys));
     }
@@ -179,7 +179,7 @@ impl From<&KuznyechikEnc> for KuznyechikDec {
     }
 }
 
-impl BlockDecrypt for KuznyechikDec {
+impl BlockCipherDecrypt for KuznyechikDec {
     fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut DecBackend(&self.keys));
     }

--- a/kuznyechik/src/sse2/mod.rs
+++ b/kuznyechik/src/sse2/mod.rs
@@ -2,8 +2,8 @@
 
 use crate::{BlockSize, Key, KeySize};
 use cipher::{
-    AlgorithmName, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser, KeyInit,
-    KeySizeUser,
+    AlgorithmName, BlockCipher, BlockCipherDecrypt, BlockCipherEncrypt, BlockClosure,
+    BlockSizeUser, KeyInit, KeySizeUser,
 };
 use core::fmt;
 

--- a/kuznyechik/src/sse2/mod.rs
+++ b/kuznyechik/src/sse2/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{BlockSize, Key, KeySize};
 use cipher::{
-    AlgorithmName, BlockCipher, BlockClosure, BlockDecrypt, BlockEncrypt, BlockSizeUser, KeyInit,
+    AlgorithmName, BlockCipher, BlockClosure, BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser, KeyInit,
     KeySizeUser,
 };
 use core::fmt;
@@ -60,13 +60,13 @@ impl From<&KuznyechikEnc> for Kuznyechik {
     }
 }
 
-impl BlockEncrypt for Kuznyechik {
+impl BlockCipherEncrypt for Kuznyechik {
     fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut EncBackend(&self.enc_keys));
     }
 }
 
-impl BlockDecrypt for Kuznyechik {
+impl BlockCipherDecrypt for Kuznyechik {
     fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut DecBackend(&self.dec_keys));
     }
@@ -121,7 +121,7 @@ impl KeyInit for KuznyechikEnc {
     }
 }
 
-impl BlockEncrypt for KuznyechikEnc {
+impl BlockCipherEncrypt for KuznyechikEnc {
     fn encrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut EncBackend(&self.keys));
     }
@@ -194,7 +194,7 @@ impl From<&KuznyechikEnc> for KuznyechikDec {
     }
 }
 
-impl BlockDecrypt for KuznyechikDec {
+impl BlockCipherDecrypt for KuznyechikDec {
     fn decrypt_with_backend(&self, f: impl BlockClosure<BlockSize = BlockSize>) {
         f.call(&mut DecBackend(&self.keys));
     }

--- a/kuznyechik/tests/mod.rs
+++ b/kuznyechik/tests/mod.rs
@@ -1,4 +1,4 @@
-use cipher::{Block, BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{Block, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use hex_literal::hex;
 use kuznyechik::{Kuznyechik, KuznyechikDec, KuznyechikEnc};
 

--- a/magma/src/lib.rs
+++ b/magma/src/lib.rs
@@ -14,7 +14,7 @@
 //! use magma::Magma;
 //! use magma::cipher::{
 //!     array::Array,
-//!     BlockEncrypt, BlockDecrypt, KeyInit,
+//!     BlockCipherEncrypt, BlockCipherDecrypt, KeyInit,
 //! };
 //! use hex_literal::hex;
 //!

--- a/rc2/tests/mod.rs
+++ b/rc2/tests/mod.rs
@@ -1,5 +1,5 @@
 use cipher::array::Array;
-use cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 
 struct Test {
     key: &'static [u8],

--- a/rc5/src/block_cipher.rs
+++ b/rc5/src/block_cipher.rs
@@ -6,7 +6,7 @@ use cipher::{
     crypto_common::BlockSizes,
     inout::InOut,
     typenum::{Diff, IsLess, Le, NonZero, Sum, Unsigned, U1, U2, U256},
-    AlgorithmName, Block, BlockBackend, BlockCipher, BlockDecrypt, BlockEncrypt, BlockSizeUser,
+    AlgorithmName, Block, BlockBackend, BlockCipher, BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser,
     KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 
@@ -95,7 +95,7 @@ where
     type BlockSize = BlockSize<W>;
 }
 
-impl<W, R, B> BlockEncrypt for RC5<W, R, B>
+impl<W, R, B> BlockCipherEncrypt for RC5<W, R, B>
 where
     W: Word,
     // Block size
@@ -208,7 +208,7 @@ where
     }
 }
 
-impl<W, R, B> BlockDecrypt for RC5<W, R, B>
+impl<W, R, B> BlockCipherDecrypt for RC5<W, R, B>
 where
     W: Word,
     // Block size

--- a/rc5/src/block_cipher.rs
+++ b/rc5/src/block_cipher.rs
@@ -6,8 +6,8 @@ use cipher::{
     crypto_common::BlockSizes,
     inout::InOut,
     typenum::{Diff, IsLess, Le, NonZero, Sum, Unsigned, U1, U2, U256},
-    AlgorithmName, Block, BlockBackend, BlockCipher, BlockCipherDecrypt, BlockCipherEncrypt, BlockSizeUser,
-    KeyInit, KeySizeUser, ParBlocksSizeUser,
+    AlgorithmName, Block, BlockBackend, BlockCipher, BlockCipherDecrypt, BlockCipherEncrypt,
+    BlockSizeUser, KeyInit, KeySizeUser, ParBlocksSizeUser,
 };
 
 use crate::core::{BlockSize, ExpandedKeyTableSize, KeyAsWordsSize, Word, RC5};

--- a/rc5/tests/mod.rs
+++ b/rc5/tests/mod.rs
@@ -2,7 +2,7 @@
 #[cfg(test)]
 mod tests {
     use cipher::consts::*;
-    use cipher::{array::Array, BlockDecrypt, BlockEncrypt, KeyInit};
+    use cipher::{array::Array, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
     use rc5::RC5;
 
     #[test]

--- a/sm4/tests/mod.rs
+++ b/sm4/tests/mod.rs
@@ -1,6 +1,6 @@
 //! Test vectors are from GM/T 0002-2012
 
-use cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use hex_literal::hex;
 use sm4::Sm4;
 

--- a/speck/tests/mod.rs
+++ b/speck/tests/mod.rs
@@ -1,6 +1,6 @@
 //! Test vectors are from The Simon and Speck Families of Lightweight Block Ciphers (Appendix C)
 
-use cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use hex_literal::hex;
 use speck_cipher::{
     Speck128_128, Speck128_192, Speck128_256, Speck32_64, Speck48_72, Speck48_96, Speck64_128,

--- a/threefish/tests/mod.rs
+++ b/threefish/tests/mod.rs
@@ -1,7 +1,7 @@
 //! Test vectors from:
 //! https://github.com/weidai11/cryptopp/blob/master/TestVectors/threefish.txt
 #![cfg(featue = "cipher")]
-use cipher::{Block, BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{Block, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use hex_literal::hex;
 use threefish::{Threefish1024, Threefish256, Threefish512};
 

--- a/twofish/tests/mod.rs
+++ b/twofish/tests/mod.rs
@@ -1,4 +1,4 @@
-use cipher::{array::Array, BlockDecrypt, BlockEncrypt, KeyInit};
+use cipher::{array::Array, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use hex_literal::hex;
 use twofish::Twofish;
 


### PR DESCRIPTION
Updates the previous `BlockEncrypt`/`BlockEncrypt` trait names to use the new ones introduced in RustCrypto/traits#1482