### PR TITLE
aes: Assert precondition required for soundness

### DIFF
--- a/aes/src/armv8/expand.rs
+++ b/aes/src/armv8/expand.rs
@@ -18,6 +18,9 @@ pub unsafe fn expand_key<const L: usize, const N: usize>(key: &[u8; L]) -> [uint
 
     let mut expanded_keys: [uint8x16_t; N] = mem::zeroed();
 
+    // Sanity check, as this is required in order for the following line to be sound.
+    // We'd rather panic than exhibit undefined behavior.
+    assert!(mem::align_of::<uint8x16_t>() >= mem::align_of::<u32>());
     let columns =
         slice::from_raw_parts_mut(expanded_keys.as_mut_ptr() as *mut u32, N * BLOCK_WORDS);
 


### PR DESCRIPTION
Feel free to edit, and let me know if I've missed something and this is actually guaranteed statically.

This came up [here](https://fuchsia-review.git.corp.google.com/c/fuchsia/+/987054/1/third_party/rust_crates/vendor/aes-0.8.3/src/armv8/expand.rs#26) when vendoring `aes` into Fuchsia.