### PR TITLE
aes: add v0.8.4 CHANGELOG entry

### DIFF
--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.4 (2024-02-13)
+### Changed
+- Assert soundness preconditions for ARMv8 key expansion ([#407], [#408])
+
+[#407]: https://github.com/RustCrypto/block-ciphers/pull/407
+[#408]: https://github.com/RustCrypto/block-ciphers/pull/408
+
 ## 0.8.3 (2023-06-17)
 ### Added
 - Support `aes_armv8` on Rust 1.61+ using `asm!` ([#365])

--- a/aes/src/armv8/expand.rs
+++ b/aes/src/armv8/expand.rs
@@ -18,8 +18,7 @@ pub unsafe fn expand_key<const L: usize, const N: usize>(key: &[u8; L]) -> [uint
 
     let mut expanded_keys: [uint8x16_t; N] = mem::zeroed();
 
-    // Sanity check, as this is required in order for the following line to be sound.
-    // We'd rather panic than exhibit undefined behavior.
+    // Sanity check, as this is required in order for the subsequent conversion to be sound.
     const _: () = assert!(mem::align_of::<uint8x16_t>() >= mem::align_of::<u32>());
     let keys_ptr: *mut u32 = expanded_keys.as_mut_ptr().cast();
     let columns = slice::from_raw_parts_mut(keys_ptr, N * BLOCK_WORDS);


### PR DESCRIPTION
This was backported in #409.

Also includes a small comment fixup.