### PR TITLE
bump `cipher` dependency to `0.5.0-pre.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,8 +81,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.2"
-source = "git+https://github.com/RustCrypto/traits.git#4459f6012afda093816e6a592828a57a8fc366ed"
+version = "0.5.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fba98785cecd0e308818a87c817576a40f99d8bab6405bf422bacd3efb6c1f"
 dependencies = [
  "blobby",
  "crypto-common",
@@ -101,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.4"
+version = "0.2.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806e4e3731d44f1340b069551225b44c2056c105cad9e67f0c46266db8a3a6b9"
+checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
 dependencies = [
  "hybrid-array",
 ]
@@ -129,9 +130,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8856b3db5eb76328f03589feb25c7a3166bfa0ae3b38b1408d546b097fa7947"
+checksum = "dcda354500b318c287a6b91c1cfbc42edd53d52d259a80783ceb5e3986fca2b2"
 dependencies = [
  "typenum",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io.cipher]
-git = "https://github.com/RustCrypto/traits.git"

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -14,14 +14,14 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 zeroize = { version = "1.5.6", optional = true, default_features = false, features = ["aarch64"] }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.3"
 
 [features]

--- a/aria/Cargo.toml
+++ b/aria/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "aria", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "belt-block", "belt", "stb"]
 
 [dependencies]
-cipher = { version = "=0.5.0-pre.2", optional = true }
+cipher = { version = "=0.5.0-pre.4", optional = true }
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -5,7 +5,7 @@ description = "Blowfish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/blowfish"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "blowfish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 byteorder = { version = "1.1", default-features = false }
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 
 [features]
 bcrypt = []

--- a/camellia/Cargo.toml
+++ b/camellia/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1.1", default-features = false }
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast5", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/cast6/Cargo.toml
+++ b/cast6/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast6", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "des", "tdes", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "idea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "kuznyechik", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "magma", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "rc2", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/rc5/Cargo.toml
+++ b/rc5/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["crypto", "rc5", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["zeroize"] }
+cipher = { version = "=0.5.0-pre.4", features = ["zeroize"] }
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 
 [features]
 zeroize = []

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1.1", default-features = false }
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "sm4", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/speck/Cargo.toml
+++ b/speck/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["crypto", "speck", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "threefish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = { version = "=0.5.0-pre.2", optional = true }
+cipher = { version = "=0.5.0-pre.4", optional = true }
 zeroize = { version = "1.6", optional = true, default-features = false }
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"]}
+cipher = { version = "=0.5.0-pre.4", features = ["dev"]}
 hex-literal = "0.4"
 
 [features]

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "twofish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.2"
+cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.2", features = ["dev"] }
+cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]


### PR DESCRIPTION
supersedes #411 