### PR TITLE
aes,kuznyechik,threefish: Rust 1.80 lint fixes

### DIFF
--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 cfg-if = "1"
 cipher = "=0.5.0-pre.4"
-zeroize = { version = "1.5.6", optional = true, default_features = false, features = ["aarch64"] }
+zeroize = { version = "1.5.6", optional = true, default-features = false, features = ["aarch64"] }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
@@ -26,6 +26,10 @@ hex-literal = "0.3"
 
 [features]
 hazmat = [] # Expose cryptographically hazardous APIs
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ["cfg(aes_compact)", "cfg(aes_force_soft)"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -22,6 +22,10 @@ hex-literal = "0.4"
 [features]
 zeroize = ["cipher/zeroize"]
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ["cfg(kuznyechik_force_soft)"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/threefish/tests/mod.rs
+++ b/threefish/tests/mod.rs
@@ -1,6 +1,6 @@
 //! Test vectors from:
 //! https://github.com/weidai11/cryptopp/blob/master/TestVectors/threefish.txt
-#![cfg(featue = "cipher")]
+#![cfg(feature = "cipher")]
 use cipher::{Block, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use hex_literal::hex;
 use threefish::{Threefish1024, Threefish256, Threefish512};


### PR DESCRIPTION
- add `lints.rust.unexpected_cfgs` to Cargo.toml
- threefish: fix typo in `cfg(feature = "cipher")`