### PR TITLE
Cut pre.1 prereleases

### DIFF
--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.9.0-pre.0"
+version = "0.9.0-pre.1"
 description = "Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-block"
-version = "0.2.0-pre.0"
+version = "0.2.0-pre.1"
 description = "belt-block block cipher implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "des"
-version = "0.9.0-pre.0"
+version = "0.9.0-pre.1"
 description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuznyechik"
-version = "0.9.0-pre.0"
+version = "0.9.0-pre.1"
 description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magma"
-version = "0.10.0-pre.0"
+version = "0.10.0-pre.1"
 description = "Magma (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts a new release of every crate which previously received a pre.0 prerelease, i.e. is used as a (dev-)dependency in downstream projects that need to be upgraded.

This includes the following:

- `aes` v0.9.0-pre.1
- `belt-block` v0.2.0-pre.1
- `des` v0.9.0-pre.1
- `kuznyechik` v0.9.0-pre.1
- `magma` v0.10.0-pre.1