### PR TITLE
aes: move `Block8` to the hazmat module

### DIFF
--- a/aes/src/armv8/hazmat.rs
+++ b/aes/src/armv8/hazmat.rs
@@ -4,7 +4,7 @@
 //! implementations in this crate, but instead provides raw AES-NI accelerated
 //! access to the AES round function gated under the `hazmat` crate feature.
 
-use crate::{Block, Block8};
+use crate::hazmat::{Block, Block8};
 use core::arch::aarch64::*;
 
 /// AES cipher (encrypt) round function.

--- a/aes/src/hazmat.rs
+++ b/aes/src/hazmat.rs
@@ -11,7 +11,11 @@
 //! We do NOT recommend using it to implement any algorithm which has not
 //! received extensive peer review by cryptographers.
 
-use crate::{soft::fixslice::hazmat as soft, Block, Block8};
+use crate::soft::fixslice::hazmat as soft;
+
+pub use crate::Block;
+/// Eight 128-bit AES blocks
+pub type Block8 = cipher::array::Array<Block, cipher::consts::U8>;
 
 #[cfg(all(target_arch = "aarch64", not(aes_force_soft)))]
 use crate::armv8::hazmat as intrinsics;

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -143,10 +143,7 @@ cfg_if! {
 }
 
 pub use cipher;
-use cipher::{
-    array::Array,
-    consts::U16,
-};
+use cipher::{array::Array, consts::U16};
 
 /// 128-bit AES block
 pub type Block = Array<u8, U16>;

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -145,13 +145,11 @@ cfg_if! {
 pub use cipher;
 use cipher::{
     array::Array,
-    consts::{U16, U8},
+    consts::U16,
 };
 
 /// 128-bit AES block
 pub type Block = Array<u8, U16>;
-/// Eight 128-bit AES blocks
-pub type Block8 = Array<Block, U8>;
 
 #[cfg(test)]
 mod tests {

--- a/aes/src/ni/hazmat.rs
+++ b/aes/src/ni/hazmat.rs
@@ -5,7 +5,7 @@
 //! access to the AES round function gated under the `hazmat` crate feature.
 
 use super::arch::*;
-use crate::{Block, Block8};
+use crate::hazmat::{Block, Block8};
 use cipher::array::{Array, ArraySize};
 
 #[target_feature(enable = "sse2")]

--- a/aes/src/soft/fixslice32.rs
+++ b/aes/src/soft/fixslice32.rs
@@ -1377,7 +1377,7 @@ pub(crate) mod hazmat {
         bitslice, inv_bitslice, inv_mix_columns_0, inv_shift_rows_1, inv_sub_bytes, mix_columns_0,
         shift_rows_1, sub_bytes, sub_bytes_nots, State,
     };
-    use crate::{Block, Block8};
+    use crate::hazmat::{Block, Block8};
 
     /// XOR the `src` block into the `dst` block in-place.
     fn xor_in_place(dst: &mut Block, src: &Block) {

--- a/aes/src/soft/fixslice64.rs
+++ b/aes/src/soft/fixslice64.rs
@@ -1432,7 +1432,7 @@ pub(crate) mod hazmat {
         bitslice, inv_bitslice, inv_mix_columns_0, inv_shift_rows_1, inv_sub_bytes, mix_columns_0,
         shift_rows_1, sub_bytes, sub_bytes_nots, State,
     };
-    use crate::{Block, Block8};
+    use crate::hazmat::{Block, Block8};
 
     /// XOR the `src` block into the `dst` block in-place.
     fn xor_in_place(dst: &mut Block, src: &Block) {

--- a/aes/tests/hazmat.rs
+++ b/aes/tests/hazmat.rs
@@ -3,7 +3,7 @@
 // TODO(tarcieri): support for using the hazmat functions with the `soft` backend
 #![cfg(feature = "hazmat")]
 
-use aes::{Block, Block8};
+use aes::hazmat::{Block, Block8};
 use hex_literal::hex;
 
 /// Round function tests vectors.


### PR DESCRIPTION
The backends were changed to use a different number of parallel blocks, so the alias is now used only by hazmat functions.

Closes #462