### PR TITLE
Update crate READMEs

### DIFF
--- a/aes/README.md
+++ b/aes/README.md
@@ -15,8 +15,6 @@ This crate implements the low-level AES block function, and is intended
 for use for implementing higher-level constructions *only*. It is NOT
 intended for direct use in applications.
 
-[Documentation][docs-link]
-
 <img src="https://raw.githubusercontent.com/RustCrypto/media/85f62bb/img/block-ciphers/aes-round.svg" width="480px">
 
 ## Security
@@ -41,18 +39,6 @@ All implementations contained in the crate are designed to execute in constant
 time, either by relying on hardware intrinsics (i.e. AES-NI on x86/x86_64), or
 using a portable implementation based on bitslicing.
 
-## Minimum Supported Rust Version
-
-Rust **1.72** or higher.
-
-Minimum supported Rust version can be changed in future releases, but it will
-be done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
-
 ## License
 
 Licensed under either of:
@@ -75,7 +61,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aes/badge.svg
 [docs-link]: https://docs.rs/aes/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260039-block-ciphers
 [build-image]: https://github.com/RustCrypto/block-ciphers/workflows/aes/badge.svg?branch=master&event=push

--- a/aria/README.md
+++ b/aria/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [ARIA] block cipher.
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/aria/badge.svg
 [docs-link]: https://docs.rs/aria/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/belt-block/README.md
+++ b/belt-block/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [BelT] block cipher specified in [STB 34.101.31-2020].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/belt-block/badge.svg
 [docs-link]: https://docs.rs/belt-block/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/blowfish/README.md
+++ b/blowfish/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [Blowfish block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/blowfish/badge.svg
 [docs-link]: https://docs.rs/blowfish/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/camellia/README.md
+++ b/camellia/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [Camellia block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/camellia/badge.svg
 [docs-link]: https://docs.rs/camellia/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/cast5/README.md
+++ b/cast5/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [CAST5 block cipher][1].
 
-[Documentation][docs-link]
-
 <img src="https://raw.githubusercontent.com/RustCrypto/meta/master/img/block-ciphers/cast5.png" width="480px">
 
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
@@ -25,18 +23,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -60,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/cast5/badge.svg
 [docs-link]: https://docs.rs/cast5/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/cast6/README.md
+++ b/cast6/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [CAST6 block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/cast6/badge.svg
 [docs-link]: https://docs.rs/cast6/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/des/README.md
+++ b/des/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [DES cipher][1], including triple DES (3DES).
 
-[Documentation][docs-link]
-
 <img src="https://raw.githubusercontent.com/RustCrypto/meta/master/img/block-ciphers/des.png" width="310px">
 
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
@@ -25,18 +23,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -60,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/des/badge.svg
 [docs-link]: https://docs.rs/des/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/gift/README.md
+++ b/gift/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [Gift block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/gift-cipher/badge.svg
 [docs-link]: https://docs.rs/gift-cipher/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/idea/README.md
+++ b/idea/README.md
@@ -10,8 +10,6 @@
 
 Experimental Pure Rust implementation of the [IDEA block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/idea/badge.svg
 [docs-link]: https://docs.rs/idea/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/kuznyechik/README.md
+++ b/kuznyechik/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the Kuznyechik (GOST R 34.12-2015) block cipher
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/kuznyechik/badge.svg
 [docs-link]: https://docs.rs/kuznyechik/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/magma/README.md
+++ b/magma/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of Magma (GOST 28147-89 and GOST R 34.12-2015) block cipher
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/magma/badge.svg
 [docs-link]: https://docs.rs/magma/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/rc2/README.md
+++ b/rc2/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [RC2 block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/rc2/badge.svg
 [docs-link]: https://docs.rs/rc2/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/rc5/README.md
+++ b/rc5/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [RC5] block cipher.
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -60,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/block-ciphers/actions/workflows/rc5.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/block-ciphers/actions/workflows/rc5.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/serpent/README.md
+++ b/serpent/README.md
@@ -10,8 +10,6 @@
 
 Experimental pure Rust implementation of the [Serpent block cipher][1].
 
-[Documentation][docs-link]
-
 <img src="https://raw.githubusercontent.com/RustCrypto/meta/master/img/block-ciphers/serpent.png" width="200px">
 
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
@@ -33,18 +31,6 @@ You can modify crate using the following configuration flags:
 - `serpent_no_unroll`: do not unroll rounds loop. Reduces binary size at the cost of slightly lower performance.
 
 The flag can be enabled using RUSTFLAGS environmental variable (e.g. RUSTFLAGS="--cfg serpent_no_unroll") or by modifying .cargo/config.
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -68,7 +54,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/serpent/badge.svg
 [docs-link]: https://docs.rs/serpent/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/sm4/README.md
+++ b/sm4/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [SM4 block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sm4/badge.svg
 [docs-link]: https://docs.rs/sm4/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/speck/README.md
+++ b/speck/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [Speck block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/speck-cipher/badge.svg
 [docs-link]: https://docs.rs/speck-cipher/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/threefish/README.md
+++ b/threefish/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [Threefish block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/threefish/badge.svg
 [docs-link]: https://docs.rs/threefish/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/twofish/README.md
+++ b/twofish/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [Twofish block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/twofish/badge.svg
 [docs-link]: https://docs.rs/twofish/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/xtea/README.md
+++ b/xtea/README.md
@@ -10,8 +10,6 @@
 
 Pure Rust implementation of the [XTEA block cipher][1].
 
-[Documentation][docs-link]
-
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
@@ -23,18 +21,6 @@ thoroughly assessed to ensure its operation is constant-time on common CPU
 architectures.
 
 USE AT YOUR OWN RISK!
-
-## Minimum Supported Rust Version
-
-Rust **1.65** or higher.
-
-Minimum supported Rust version can be changed in the future, but it will be
-done with a minor version bump.
-
-## SemVer Policy
-
-- All on-by-default features of this library are covered by SemVer
-- MSRV is considered exempt from SemVer as noted above
 
 ## License
 
@@ -58,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/xtea/badge.svg
 [docs-link]: https://docs.rs/xtea/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg


### PR DESCRIPTION
- Update MSRV badges.
- Remove the text-based "documentation" link. It's redundant, especially when readme is included in crate docs.
- Remove the "Minimum Supported Rust Version" section. After update to the 2024 edition we have a more relaxed MSRV policy, so the MSRV badge should be sufficient.
- Remove the "SemVer Policy" section. After the MSRV policy change we have the default SemVer policy (i.e. all features and public APIs are subject to SemVer), so we do not need to say it explicitly.