### PR TITLE
Minor Documentation and Test Function Name Fixes

### DIFF
--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -79,7 +79,7 @@
 //! // Implementation supports parallel block processing. Number of blocks
 //! // processed in parallel depends in general on hardware capabilities.
 //! // This is achieved by instruction-level parallelism (ILP) on a single
-//! // CPU core, which is differen from multi-threaded parallelism.
+//! // CPU core, which is different from multi-threaded parallelism.
 //! let mut blocks = [block; 100];
 //! cipher.encrypt_blocks(&mut blocks);
 //!

--- a/cast5/tests/mod.rs
+++ b/cast5/tests/mod.rs
@@ -38,7 +38,7 @@ fn rfc2144_b1() {
 /// Test based on RFC 2144 Appendix B.2
 /// https://tools.ietf.org/html/rfc2144#appendix-B.1
 #[test]
-fn full_maintance_test() {
+fn full_maintenance_test() {
     let a = hex!("0123456712345678234567893456789A");
     let b = hex!("0123456712345678234567893456789A");
 


### PR DESCRIPTION


**Description:**
- Clarified a comment in AES documentation for better readability.
- Fixed a typo in the CAST5 test function name (`full_maintance_test` → `full_maintenance_test`).