### PR TITLE
aes: use 1.89.0-beta.2 for VAES CI

### DIFF
--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -61,7 +61,7 @@ jobs:
     if: false # TODO: temp disabled due to unpublished prerelease dependencies
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}
 
   # Tests for the AES-NI backend
   aesni:
@@ -108,7 +108,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            rust: nightly-2025-05-28
+            rust: 1.89.0-beta.2
     steps:
       - uses: actions/checkout@v4
       - name: Install Intel SDE
@@ -144,7 +144,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            rust: nightly-2025-05-28
+            rust: 1.89.0-beta.2
     steps:
       - uses: actions/checkout@v4
       - name: Install Intel SDE


### PR DESCRIPTION
Ensures we'll be able to build against the forthcoming stable release