### PR TITLE
Bump `cipher` to v0.5.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,8 +37,9 @@ checksum = "4a859067dcb257cb2ae028cb821399b55140b76fb8b2a360e052fe109019db43"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils.git#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -84,14 +85,15 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits.git#062af9bd26c388f371dfec79cdaf889b515fe381"
+version = "0.5.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -111,8 +113,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.3"
-source = "git+https://github.com/RustCrypto/traits.git#062af9bd26c388f371dfec79cdaf889b515fe381"
+version = "0.2.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
 dependencies = [
  "hybrid-array",
 ]
@@ -158,8 +161,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.5"
-source = "git+https://github.com/RustCrypto/utils.git#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.2.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
 dependencies = [
  "hybrid-array",
 ]
@@ -175,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "magma"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-block-buffer = { git = "https://github.com/RustCrypto/utils" }
-cipher = { git = "https://github.com/RustCrypto/traits" }
-inout = { git = "https://github.com/RustCrypto/utils" }

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 zeroize = { version = "1.5.6", optional = true, default-features = false, features = [
     "aarch64",
 ] }
@@ -23,7 +23,7 @@ zeroize = { version = "1.5.6", optional = true, default-features = false, featur
 cpufeatures = "0.2"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/aria/Cargo.toml
+++ b/aria/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "aria", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "belt-block", "belt", "stb"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.0", optional = true }
+cipher = { version = "0.5.0-rc.1", optional = true }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "blowfish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 byteorder = { version = "1.1", default-features = false }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 
 [features]
 bcrypt = []

--- a/camellia/Cargo.toml
+++ b/camellia/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1.1", default-features = false }
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast5", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cast6/Cargo.toml
+++ b/cast6/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast6", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "des", "tdes", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/gift/Cargo.toml
+++ b/gift/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "gift", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "idea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "kuznyechik", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 cfg-if = "1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "magma", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "rc2", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/rc5/Cargo.toml
+++ b/rc5/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["crypto", "rc5", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "serpent", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "sm4", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/speck/Cargo.toml
+++ b/speck/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "speck", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "threefish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.0", optional = true }
+cipher = { version = "0.5.0-rc.1", optional = true }
 zeroize = { version = "1.6", optional = true, default-features = false }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "twofish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/xtea/Cargo.toml
+++ b/xtea/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "xtea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]


### PR DESCRIPTION
Notably this includes `hybrid-array` v0.4 support