### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 dependencies = [
  "byteorder",
  "cipher",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "gift-cipher"
-version = "0.0.1-rc.0"
+version = "0.0.1-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -185,7 +185,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "magma"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 description = "Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-block"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "belt-block block cipher implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blowfish"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 description = "Blowfish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "des"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/gift/Cargo.toml
+++ b/gift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gift-cipher"
-version = "0.0.1-rc.0"
+version = "0.0.1-rc.1"
 description = "Pure Rust implementation of the Gift block cipher"
 authors = ["RustCrypto Developers", "Schmid7k"]
 license = "MIT OR Apache-2.0"

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuznyechik"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magma"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 description = "Magma (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following:
- `aes` v0.9.0-rc.1
- `belt-block` v0.2.0-rc.1
- `blowfish` v0.10.0-rc.1
- `des` v0.9.0-rc.1
- `gift-cipher` v0.0.1-rc.1
- `kuznyechik` v0.9.0-rc.1
- `magma` v0.10.0-rc.1