### PR TITLE
magma: fix typos

### DIFF
--- a/magma/src/sboxes.rs
+++ b/magma/src/sboxes.rs
@@ -41,9 +41,9 @@ pub(crate) trait SboxExt: Sbox {
     fn apply_sbox(a: u32) -> u32 {
         let mut v = 0;
         for i in 0..4 {
-            let shft = 8 * i;
-            let k = ((a & (0xffu32 << shft)) >> shft) as usize;
-            v += (Self::EXP_SBOX[i][k] as u32) << shft;
+            let shift = 8 * i;
+            let k = ((a & (0xffu32 << shift)) >> shift) as usize;
+            v += (Self::EXP_SBOX[i][k] as u32) << shift;
         }
         v
     }


### PR DESCRIPTION
The `typos` CI action recently started complaining about these:

https://github.com/RustCrypto/block-ciphers/actions/runs/18258797158/job/51983873161?pr=505

See also: RustCrypto/hashes#741