### PR TITLE
rc6: 2024 edition; upgrade to `cipher` v0.5.0-rc.1

### DIFF
--- a/.github/workflows/rc6.yml
+++ b/.github/workflows/rc6.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRVs
+          - 1.85.0 # MSRVs
           - stable
         target:
           - thumbv7em-none-eabi
@@ -38,14 +38,14 @@ jobs:
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRVs
+          - 1.85.0 # MSRVs
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "rc6"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "cipher",
 ]

--- a/rc6/Cargo.toml
+++ b/rc6/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "rc6"
-version = "0.1.0"
+version = "0.0.0"
 description = "RC6 block cipher"
 authors = ["RustCrypto Developers"]
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/RustCrypto/block-ciphers"
@@ -11,10 +12,10 @@ keywords = ["crypto", "rc6", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = { version = "0.5.0-pre.6", features = ["zeroize"] }
+cipher = { version = "0.5.0-rc.1", features = ["zeroize"] }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-pre.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 
 [features]
 zeroize = []

--- a/rc6/src/core/backend.rs
+++ b/rc6/src/core/backend.rs
@@ -8,7 +8,7 @@ use cipher::{
     array::{Array, ArraySize},
     crypto_common::BlockSizes,
     inout::InOut,
-    typenum::{Diff, IsLess, Le, NonZero, Sum, Unsigned, U1, U2, U256, U4},
+    typenum::{Diff, IsLess, Le, NonZero, Sum, U1, U2, U4, U256, Unsigned},
 };
 
 use super::{

--- a/rc6/tests/mod.rs
+++ b/rc6/tests/mod.rs
@@ -3,7 +3,7 @@
 #[allow(deprecated)] // uses `clone_from_slice`
 mod tests {
     use cipher::consts::*;
-    use cipher::{array::Array, BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
+    use cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit, array::Array};
     use rc6::RC6;
 
     #[test]


### PR DESCRIPTION
Updates `rc6` to use the latest Rust version and version of `cipher` that all of the other crates are using