### PR TITLE
Cut rc.2 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 dependencies = [
  "byteorder",
  "cipher",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "gift-cipher"
-version = "0.0.1-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -185,7 +185,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "magma"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -208,21 +208,21 @@ dependencies = [
 
 [[package]]
 name = "rc6"
-version = "0.0.0"
+version = "0.1.0-rc.2"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "serpent"
-version = "0.6.0-pre"
+version = "0.6.0-rc.2"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "sm4"
-version = "0.6.0-pre"
+version = "0.6.0-rc.2"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "speck-cipher"
-version = "0.0.0"
+version = "0.1.0-rc.2"
 dependencies = [
  "cipher",
  "hex-literal",

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 description = "Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-block"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 description = "belt-block block cipher implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blowfish"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 description = "Blowfish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "des"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/gift/Cargo.toml
+++ b/gift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gift-cipher"
-version = "0.0.1-rc.1"
+version = "0.1.0-rc.2"
 description = "Pure Rust implementation of the Gift block cipher"
 authors = ["RustCrypto Developers", "Schmid7k"]
 license = "MIT OR Apache-2.0"

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuznyechik"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magma"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 description = "Magma (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/rc6/Cargo.toml
+++ b/rc6/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc6"
-version = "0.0.0"
+version = "0.1.0-rc.2"
 description = "RC6 block cipher"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serpent"
-version = "0.6.0-pre"
+version = "0.6.0-rc.2"
 description = "Serpent block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm4"
-version = "0.6.0-pre"
+version = "0.6.0-rc.2"
 description = "SM4 block cipher algorithm"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/speck/Cargo.toml
+++ b/speck/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speck-cipher"
-version = "0.0.0"
+version = "0.1.0-rc.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Speck block cipher algorithm"


### PR DESCRIPTION
Cuts the following prereleases:

- `aes` v0.9.0-rc.2
- `belt-block` v0.2.0-rc.2
- `blowfish` v0.10.0-rc.2
- `des` v0.9.0-rc.2
- `gift-cipher` v0.1.0-rc.2
- `kuznyechik` v0.9.0-rc.2
- `magma` v0.10.0-rc.2
- `rc6` v0.1.0-rc.2
- `serpent` v0.6.0-rc.2
- `sm4` v0.6.0-rc.2
- `speck-cipher` v0.1.0-rc.2