### PR TITLE
aes: vaes detection is provided by cpufeatures-0.2.12

### DIFF
--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -18,7 +18,7 @@ cipher = "0.5.0-rc.2"
 zeroize = { version = "1.5.6", optional = true, default-features = false, features = ["aarch64"] }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
-cpufeatures = "0.2"
+cpufeatures = "0.2.12"
 
 [dev-dependencies]
 cipher = { version = "0.5.0-rc.2", features = ["dev"] }


### PR DESCRIPTION
This fixes a compilation error when bumping to aes-0.9.0-rc.2 (which brings a vaes backend):
```
error: no rules expected `"vaes"`
   --> $HOME/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aes-0.9.0-rc.2/src/x86.rs:38:38
    |
 38 |     cpufeatures::new!(features_vaes, "vaes");
    |                                      ^^^^^^ no rules expected this token in macro call
```