### PR TITLE
Bump `cipher` dependency to v0.5.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "89af0b093cc13baa4e51e64e65ec2422f7e73aea0e612e5ad3872986671622f1"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
+checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -91,9 +91,9 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
+checksum = "98d708bac5451350d56398433b19a7889022fa9187df1a769c0edbc3b2c03167"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
 dependencies = [
  "hybrid-array",
 ]

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -14,14 +14,14 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 zeroize = { version = "1.5.6", optional = true, default-features = false, features = ["aarch64"] }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2.12"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/aria/Cargo.toml
+++ b/aria/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "aria", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "belt-block", "belt", "stb"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.2", optional = true }
+cipher = { version = "0.5.0-rc.3", optional = true }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "blowfish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 byteorder = { version = "1.1", default-features = false }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 
 [features]
 bcrypt = []

--- a/camellia/Cargo.toml
+++ b/camellia/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1.1", default-features = false }
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast5", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cast6/Cargo.toml
+++ b/cast6/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast6", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "des", "tdes", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/gift/Cargo.toml
+++ b/gift/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "gift", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "idea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "kuznyechik", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 cfg-if = "1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "magma", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "rc2", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/rc5/Cargo.toml
+++ b/rc5/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["crypto", "rc5", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/rc6/Cargo.toml
+++ b/rc6/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["crypto", "rc6", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["zeroize"] }
+cipher = { version = "0.5.0-rc.3", features = ["zeroize"] }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 
 [features]
 zeroize = []

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "serpent", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "sm4", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/speck/Cargo.toml
+++ b/speck/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "speck", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "threefish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.2", optional = true }
+cipher = { version = "0.5.0-rc.3", optional = true }
 zeroize = { version = "1.6", optional = true, default-features = false }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "twofish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/xtea/Cargo.toml
+++ b/xtea/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "xtea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
+cipher = "0.5.0-rc.3"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.2", features = ["dev"] }
+cipher = { version = "0.5.0-rc.3", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]


### PR DESCRIPTION
This brings `getrandom` v0.4.0-rc.0 and `rand_core` v0.10.0-rc-3