### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "aria"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -61,7 +61,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "camellia"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 dependencies = [
  "byteorder",
  "cipher",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cast5"
-version = "0.12.0-pre"
+version = "0.12.0-rc.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "cast6"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "idea"
-version = "0.6.0-pre"
+version = "0.6.0-rc.0"
 dependencies = [
  "cipher",
 ]
@@ -193,14 +193,14 @@ dependencies = [
 
 [[package]]
 name = "rc2"
-version = "0.9.0-pre.0"
+version = "0.9.0-rc.0"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "rc5"
-version = "0.1.0-pre"
+version = "0.1.0-rc.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "threefish"
-version = "0.6.0-pre"
+version = "0.6.0-rc.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "twofish"
-version = "0.8.0-pre"
+version = "0.8.0-rc.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -261,7 +261,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "xtea"
-version = "0.0.1-pre.0"
+version = "0.1.0-rc.0"
 dependencies = [
  "cipher",
 ]

--- a/aria/Cargo.toml
+++ b/aria/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 description = "Pure Rust implementation of the ARIA Encryption Algorithm"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/camellia/Cargo.toml
+++ b/camellia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camellia"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 description = "Camellia block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cast5"
-version = "0.12.0-pre"
+version = "0.12.0-rc.0"
 description = "CAST5 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cast6/Cargo.toml
+++ b/cast6/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cast6"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 description = "CAST6 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idea"
-version = "0.6.0-pre"
+version = "0.6.0-rc.0"
 description = "IDEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc2"
-version = "0.9.0-pre.0"
+version = "0.9.0-rc.0"
 description = "RC2 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/rc5/Cargo.toml
+++ b/rc5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc5"
-version = "0.1.0-pre"
+version = "0.1.0-rc.0"
 description = "RC5 block cipher"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "threefish"
-version = "0.6.0-pre"
+version = "0.6.0-rc.0"
 description = "Threefish block cipher"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twofish"
-version = "0.8.0-pre"
+version = "0.8.0-rc.0"
 description = "Twofish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/xtea/CHANGELOG.md
+++ b/xtea/CHANGELOG.md
@@ -4,15 +4,3 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## 0.2.0 (UNRELEASED)
-### Changed
-- Bump `cipher` dependency to v0.5
-- Edition changed to 2024 and MSRV bumped to 1.85 ([#472])
-- Relax MSRV policy and allow MSRV bumps in patch releases ([#477])
-
-[#472]: https://github.com/RustCrypto/block-ciphers/pull/472
-[#477]: https://github.com/RustCrypto/block-ciphers/pull/477
-
-## 0.1.0 (2024-05-11)
-- Initial release

--- a/xtea/Cargo.toml
+++ b/xtea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtea"
-version = "0.0.1-pre.0"
+version = "0.1.0-rc.0"
 description = "XTEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts release candidates of all crates which have not yet received such a release:

- `aria` v0.2.0-rc.0
- `camellia` v0.2.0-rc.0
- `cast5` v0.12.0-rc.0
- `cast6` v0.2.0-rc.0
- `idea` v0.6.0-rc.0
- `rc2` v0.9.0-rc.0
- `rc5` v0.1.0-rc.0
- `threefish` v0.6.0-rc.0
- `twofish` v0.8.0-rc.0
- `xtea` v0.1.0-rc.0