### PR TITLE
Bump `cipher` dependency to v0.5.0-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.6"
+version = "0.5.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba4d87abf4032a6d927f84b71af5086128a3349b929b4501c51a0fe0981a937"
+checksum = "cf7e48717e58fd82d6470086ab1c0e12f56426b4ef96c84bb84b9c3fefc6d9c7"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "5569e5de27d32e673283717728eb5b0e4f30898b523f151a19c51e6188006599"
 dependencies = [
  "hybrid-array",
 ]

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -14,14 +14,14 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 zeroize = { version = "1.5.6", optional = true, default-features = false, features = ["aarch64"] }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2.12"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/aria/Cargo.toml
+++ b/aria/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "aria", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/RustCrypto/block-ciphers"
 keywords = ["crypto", "belt-block", "belt", "stb"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.6", optional = true }
+cipher = { version = "0.5.0-rc.7", optional = true }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "blowfish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 byteorder = { version = "1.1", default-features = false }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 
 [features]
 bcrypt = []

--- a/camellia/Cargo.toml
+++ b/camellia/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 byteorder = { version = "1.1", default-features = false }
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast5", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cast6/Cargo.toml
+++ b/cast6/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "cast6", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "des", "tdes", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/gift/Cargo.toml
+++ b/gift/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "gift", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "idea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "kuznyechik", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 cfg-if = "1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "magma", "gost", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "rc2", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/rc5/Cargo.toml
+++ b/rc5/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["crypto", "rc5", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/rc6/Cargo.toml
+++ b/rc6/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["crypto", "rc6", "block-cipher"]
 categories = ["cryptography"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["zeroize"] }
+cipher = { version = "0.5.0-rc.7", features = ["zeroize"] }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 
 [features]
 zeroize = []

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "serpent", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "sm4", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/speck/Cargo.toml
+++ b/speck/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "speck", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "threefish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.6", optional = true }
+cipher = { version = "0.5.0-rc.7", optional = true }
 zeroize = { version = "1.6", optional = true, default-features = false }
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "twofish", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/xtea/Cargo.toml
+++ b/xtea/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "xtea", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
+cipher = "0.5.0-rc.7"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.6", features = ["dev"] }
+cipher = { version = "0.5.0-rc.7", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize"]


### PR DESCRIPTION
Includes transitive `rand_core` v0.10 bump (though it doesn't impact this repo)