### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "aria"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 dependencies = [
  "byteorder",
  "cipher",
@@ -61,7 +61,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "camellia"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "byteorder",
  "cipher",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cast5"
-version = "0.12.0-rc.0"
+version = "0.12.0-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "cast6"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "gift-cipher"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "idea"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 dependencies = [
  "cipher",
 ]
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -185,7 +185,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "magma"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -193,14 +193,14 @@ dependencies = [
 
 [[package]]
 name = "rc2"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "rc5"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -208,21 +208,21 @@ dependencies = [
 
 [[package]]
 name = "rc6"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "serpent"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "sm4"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "speck-cipher"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "threefish"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "twofish"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -261,7 +261,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "xtea"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "cipher",
 ]

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 description = "Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/aria/Cargo.toml
+++ b/aria/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "Pure Rust implementation of the ARIA Encryption Algorithm"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/belt-block/Cargo.toml
+++ b/belt-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-block"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 description = "belt-block block cipher implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/blowfish/Cargo.toml
+++ b/blowfish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blowfish"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 description = "Blowfish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/camellia/Cargo.toml
+++ b/camellia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camellia"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "Camellia block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cast5/Cargo.toml
+++ b/cast5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cast5"
-version = "0.12.0-rc.0"
+version = "0.12.0-rc.1"
 description = "CAST5 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cast6/Cargo.toml
+++ b/cast6/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cast6"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "CAST6 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/des/Cargo.toml
+++ b/des/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "des"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 description = "DES and Triple DES (3DES, TDES) block ciphers implementation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/gift/Cargo.toml
+++ b/gift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gift-cipher"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 description = "Pure Rust implementation of the Gift block cipher"
 authors = ["RustCrypto Developers", "Schmid7k"]
 license = "MIT OR Apache-2.0"

--- a/idea/Cargo.toml
+++ b/idea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idea"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 description = "IDEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/kuznyechik/Cargo.toml
+++ b/kuznyechik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuznyechik"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 description = "Kuznyechik (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/magma/Cargo.toml
+++ b/magma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magma"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 description = "Magma (GOST R 34.12-2015) block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/rc2/Cargo.toml
+++ b/rc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc2"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 description = "RC2 block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/rc5/Cargo.toml
+++ b/rc5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc5"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 description = "RC5 block cipher"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/rc6/Cargo.toml
+++ b/rc6/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc6"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 description = "RC6 block cipher"
 authors = ["RustCrypto Developers"]
 edition = "2024"

--- a/serpent/Cargo.toml
+++ b/serpent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serpent"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 description = "Serpent block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sm4/Cargo.toml
+++ b/sm4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm4"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 description = "SM4 block cipher algorithm"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/speck/Cargo.toml
+++ b/speck/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speck-cipher"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Speck block cipher algorithm"

--- a/threefish/Cargo.toml
+++ b/threefish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "threefish"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 description = "Threefish block cipher"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/twofish/Cargo.toml
+++ b/twofish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twofish"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 description = "Twofish block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/xtea/Cargo.toml
+++ b/xtea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtea"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 description = "XTEA block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Closes #529

Releases the following with a `cipher` v0.5.0-rc.7 dependency, which transitively depends on `rand_core` v0.10 by way of `crypto-common`:

- `aes` v0.9.0-rc.3
- `aria` v0.2.0-rc.1
- `belt-block` v0.2.0-rc.3
- `blowfish` v0.10.0-rc.3
- `camellia` v0.2.0-rc.1
- `cast5` v0.12.0-rc.1
- `cast6` v0.2.0-rc.1
- `des` v0.9.0-rc.3
- `gift-cipher` v0.1.0-rc.3
- `idea` v0.6.0-rc.1
- `kuznyechik` v0.9.0-rc.3
- `magma` v0.10.0-rc.3
- `rc2` v0.9.0-rc.1
- `rc5` v0.1.0-rc.1
- `rc6` v0.1.0-rc.3
- `serpent` v0.6.0-rc.3
- `sm4` v0.6.0-rc.3
- `speck-cipher` v0.1.0-rc.3
- `threefish` v0.6.0-rc.1
- `twofish` v0.8.0-rc.1
- `xtea` v0.1.0-rc.1