### PR TITLE
Release aes v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cipher",
  "cpubits",

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.1 (UNRELEASED)
+## 0.9.1 (2026-05-26)
 ### Fixed
 - Minimal version of `zeroize` dependency ([#562])
 - Build warnings on AArch64 targets ([#562])
 
 [#562]: https://github.com/RustCrypto/block-ciphers/pull/562
 
-## 0.9.0 (2026-04-10)
+## 0.9.0 (2026-04-10) [YANKED]
 ### Changed
 - Bump `cipher` dependency to v0.5
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#472])

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.1 (2026-05-26)
+## 0.9.1 (2026-05-27)
 ### Fixed
 - Minimal version of `zeroize` dependency ([#562])
 - Build warnings on AArch64 targets ([#562])

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.9.0"
+version = "0.9.1"
 description = "Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Fixed
- Minimal version of `zeroize` dependency ([#562])
- Build warnings on AArch64 targets ([#562])

[#562]: https://github.com/RustCrypto/block-ciphers/pull/562