### PR TITLE
camellia: drop unused byteorder dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,6 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 name = "camellia"
 version = "0.2.0"
 dependencies = [
- "byteorder",
  "cipher",
 ]
 

--- a/camellia/CHANGELOG.md
+++ b/camellia/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (UNRELEASED)
+### Changed
+- Removed unused `byteorder` dependency ([#566])
+
+[#566]: https://github.com/RustCrypto/block-ciphers/pull/566
+
 ## 0.2.0 (2026-04-10)
 ### Changed
 - Bump `cipher` dependency to v0.5.0

--- a/camellia/Cargo.toml
+++ b/camellia/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["crypto", "camellia", "block-cipher"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-byteorder = { version = "1.1", default-features = false }
 cipher = "0.5"
 
 [dev-dependencies]


### PR DESCRIPTION
`byteorder` has been unused since #446 was merged. 
