### PR TITLE
Release aes v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cipher",
  "cpubits",

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.2 (UNRELEASED)
+## 0.9.2 (2026-07-24)
 ### Changed
 - Internal implementation of backends ([#560], [#575])
 

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.2 (2026-07-24)
+## 0.9.2 (2026-07-27)
 ### Added
 - `hardware_accelerated` function ([#579])
 

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 description = "Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- `hardware_accelerated` function ([#579])

### Changed
- Internal implementation of backends ([#560], [#575])

### Fixed
- Performance regression on x86 targets ([#575])

[#560]: https://github.com/RustCrypto/block-ciphers/pull/560
[#575]: https://github.com/RustCrypto/block-ciphers/pull/575
[#579]: https://github.com/RustCrypto/block-ciphers/pull/579