### PR TITLE
aes: add `hardware_accelerated` function

### DIFF
--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.9.2 (UNRELEASED)
+### Added
+- `hardware_accelerated` function ([#579])
+
 ### Changed
 - Internal implementation of backends ([#560], [#575])
 
@@ -14,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#560]: https://github.com/RustCrypto/block-ciphers/pull/560
 [#575]: https://github.com/RustCrypto/block-ciphers/pull/575
+[#579]: https://github.com/RustCrypto/block-ciphers/pull/579
 
 ## 0.9.1 (2026-05-27)
 ### Fixed

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -196,6 +196,21 @@ cfg_if! {
     }
 }
 
+/// Returns `true` if hardware acceleration is avialble.
+pub fn hardware_accelerated() -> bool {
+    cfg_if! {
+        if #[cfg(aes_backend = "soft")] {
+            false
+        } else if #[cfg(any(target_arch = "x86_64", target_arch = "x86"))] {
+            features_aes::get()
+        } else if #[cfg(target_arch = "aarch64")] {
+            features_aes::get()
+        } else {
+            false
+        }
+    }
+}
+
 macro_rules! impl_key_init {
     ($name:ident, $soft_name:ident, $key_size:ty, $inner:path) => {
         impl KeySizeUser for $name {

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -196,7 +196,9 @@ cfg_if! {
     }
 }
 
-/// Returns `true` if hardware acceleration is avialble.
+/// Returns `true` if this crate can use AES hardware acceleration on the current machine.
+///
+/// This is a runtime check performed on the machine where the code is executed.
 pub fn hardware_accelerated() -> bool {
     cfg_if! {
         if #[cfg(aes_backend = "soft")] {

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -199,6 +199,14 @@ cfg_if! {
 /// Returns `true` if this crate can use AES hardware acceleration on the current machine.
 ///
 /// This is a runtime check performed on the machine where the code is executed.
+///
+/// ```
+/// if aes::hardware_accelerated() {
+///     println!("AES hardware acceleration is available");
+/// } else {
+///     println!("WARNING: using software fallback for AES");
+/// }
+/// ```
 pub fn hardware_accelerated() -> bool {
     cfg_if! {
         if #[cfg(aes_backend = "soft")] {


### PR DESCRIPTION
The function allows to check whether supported AES hardware acceleration is available.

Closes #549.