### PR TITLE
kuznyechik: remove unnecessary mut in f.call()

### DIFF
--- a/kuznyechik/src/big_soft/mod.rs
+++ b/kuznyechik/src/big_soft/mod.rs
@@ -40,24 +40,24 @@ impl From<EncKeys> for DecKeys {
 
 impl BlockCipherEncrypt for crate::Kuznyechik {
     fn encrypt_with_backend(&self, f: impl BlockCipherEncClosure<BlockSize = BlockSize>) {
-        f.call(&mut EncBackend(&self.keys.enc));
+        f.call(&EncBackend(&self.keys.enc));
     }
 }
 
 impl BlockCipherDecrypt for crate::Kuznyechik {
     fn decrypt_with_backend(&self, f: impl BlockCipherDecClosure<BlockSize = BlockSize>) {
-        f.call(&mut DecBackend(&self.keys.dec));
+        f.call(&DecBackend(&self.keys.dec));
     }
 }
 
 impl BlockCipherEncrypt for crate::KuznyechikEnc {
     fn encrypt_with_backend(&self, f: impl BlockCipherEncClosure<BlockSize = BlockSize>) {
-        f.call(&mut EncBackend(&self.keys.0));
+        f.call(&EncBackend(&self.keys.0));
     }
 }
 
 impl BlockCipherDecrypt for crate::KuznyechikDec {
     fn decrypt_with_backend(&self, f: impl BlockCipherDecClosure<BlockSize = BlockSize>) {
-        f.call(&mut DecBackend(&self.keys.0));
+        f.call(&DecBackend(&self.keys.0));
     }
 }

--- a/kuznyechik/src/compact_soft/mod.rs
+++ b/kuznyechik/src/compact_soft/mod.rs
@@ -34,24 +34,24 @@ impl EncKeys {
 
 impl BlockCipherEncrypt for crate::Kuznyechik {
     fn encrypt_with_backend(&self, f: impl BlockCipherEncClosure<BlockSize = BlockSize>) {
-        f.call(&mut EncBackend(&self.keys.0));
+        f.call(&EncBackend(&self.keys.0));
     }
 }
 
 impl BlockCipherDecrypt for crate::Kuznyechik {
     fn decrypt_with_backend(&self, f: impl BlockCipherDecClosure<BlockSize = BlockSize>) {
-        f.call(&mut DecBackend(&self.keys.0));
+        f.call(&DecBackend(&self.keys.0));
     }
 }
 
 impl BlockCipherEncrypt for crate::KuznyechikEnc {
     fn encrypt_with_backend(&self, f: impl BlockCipherEncClosure<BlockSize = BlockSize>) {
-        f.call(&mut EncBackend(&self.keys.0));
+        f.call(&EncBackend(&self.keys.0));
     }
 }
 
 impl BlockCipherDecrypt for crate::KuznyechikDec {
     fn decrypt_with_backend(&self, f: impl BlockCipherDecClosure<BlockSize = BlockSize>) {
-        f.call(&mut DecBackend(&self.keys.0));
+        f.call(&DecBackend(&self.keys.0));
     }
 }


### PR DESCRIPTION
## Summary

Newer clippy versions flag `unnecessary_mut_passed` when calling
`f.call(&mut Backend)` on the `BlockCipherEncClosure::call` /
`BlockCipherDecClosure::call` trait methods, which take `&self` (not
`&mut self`).

With `-D warnings` in CI, this breaks the build on newer toolchains.

Remove the excess `mut` in both `big_soft/mod.rs` and
`compact_soft/mod.rs`.

## Verification

`cargo clippy --all --exclude aes --all-features -- -D warnings` passes.