### PR TITLE
aes: disable `aarch64_aes` backend on Miri

### DIFF
--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -318,3 +318,19 @@ jobs:
           toolchain: 1.89.0 # MSRV
           components: clippy
       - run: cargo clippy --features hazmat -- -D warnings
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: miri
+      - run: ${{ matrix.deps }}
+      - run: cargo miri test --all-features
+      - run: cargo miri test --all-features
+        env:
+          RUSTFLAGS: '-Dwarnings --cfg aes_backend="soft"'
+      - run: cargo miri test --all-features --target aarch64-apple-darwin

--- a/.github/workflows/aes.yml
+++ b/.github/workflows/aes.yml
@@ -326,7 +326,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: nightly
           components: miri
       - run: ${{ matrix.deps }}
       - run: cargo miri test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - MSRV bumped to 1.89 ([#580])
 - VAES-256 and VAES-512 backends on x86 targets are now supported by default ([#580])
+- Disable `aarch64_aes` backend on Miri ([#586])
 
 ### Removed
 - `aes_backend = "avx256"` and `aes_backend = "avx512"` configuration flags ([#580])
 
 [#580]: https://github.com/RustCrypto/block-ciphers/pull/580
+[#586]: https://github.com/RustCrypto/block-ciphers/pull/586
 
 ## 0.9.2 (2026-07-27)
 ### Added

--- a/aes/src/backends.rs
+++ b/aes/src/backends.rs
@@ -3,7 +3,8 @@ pub(crate) mod soft;
 cpubits::cfg_if! {
     if #[cfg(aes_backend = "soft")] {
         // Do not add other backends if software backend is forced
-    } else if #[cfg(target_arch = "aarch64")] {
+    } else if #[cfg(all(target_arch = "aarch64", not(miri)))] {
+        // Note: Miri does not support AArch64 AES intrinsics yet
         pub(crate) mod aarch64_aes;
     } else if #[cfg(any(target_arch = "x86_64", target_arch = "x86"))] {
         pub(crate) mod x86_aes;

--- a/aes/src/hazmat.rs
+++ b/aes/src/hazmat.rs
@@ -22,11 +22,15 @@ pub type Block8 = cipher::array::Array<Block, cipher::consts::U8>;
 macro_rules! if_intrinsics_available {
     ($body:expr) => {{
         #[cfg(all(
-            any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"),
+            any(
+                target_arch = "x86",
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", not(miri))
+            ),
             not(aes_backend = "soft")
         ))]
         if crate::features_aes::get() {
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", not(miri)))]
             use crate::backends::aarch64_aes::hazmat as intrinsics;
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             use crate::backends::x86_aes::hazmat as intrinsics;

--- a/aes/src/lib.rs
+++ b/aes/src/lib.rs
@@ -170,7 +170,7 @@ cfg_if! {
             }
         }
 
-    } else if #[cfg(target_arch = "aarch64")] {
+    } else if #[cfg(all(target_arch = "aarch64", not(miri)))] {
         cpufeatures::new!(features_aes, "aes");
 
         #[derive(Clone, Copy)]
@@ -207,7 +207,7 @@ pub fn hardware_accelerated() -> bool {
             false
         } else if #[cfg(any(target_arch = "x86_64", target_arch = "x86"))] {
             features_aes::get()
-        } else if #[cfg(target_arch = "aarch64")] {
+        } else if #[cfg(all(target_arch = "aarch64", not(miri)))] {
             features_aes::get()
         } else {
             false
@@ -237,7 +237,7 @@ macro_rules! impl_key_init {
                             let inner = Inner { aes };
                             return Self { inner, token };
                         }
-                    } else if #[cfg(target_arch = "aarch64")] {
+                    } else if #[cfg(all(target_arch = "aarch64", not(miri)))] {
                         if token.aes.get() {
                             // SAFETY: we confirmed that the required target features are available
                             let aes = unsafe { backends::aarch64_aes::$name::new(key) };
@@ -286,7 +286,7 @@ macro_rules! impl_encrypt {
                             unsafe { aes.encrypt(f) };
                             return;
                         }
-                    } else if #[cfg(target_arch = "aarch64")] {
+                    } else if #[cfg(all(target_arch = "aarch64", not(miri)))] {
                         if self.token.aes.get() {
                             // SAFETY: we access correct union variant
                             let aes = unsafe { &self.inner.aes };
@@ -336,7 +336,7 @@ macro_rules! impl_decrypt {
                             unsafe { backend.decrypt(f) };
                             return;
                         }
-                    } else if #[cfg(target_arch = "aarch64")] {
+                    } else if #[cfg(all(target_arch = "aarch64", not(miri)))] {
                         if self.token.aes.get() {
                             // SAFETY: we access correct union variant
                             let backend = unsafe { &self.inner.aes };
@@ -375,7 +375,7 @@ macro_rules! impl_from_enc {
                             let inner = Inner { aes };
                             return Self { inner, token };
                         }
-                    } else if #[cfg(target_arch = "aarch64")] {
+                    } else if #[cfg(all(target_arch = "aarch64", not(miri)))] {
                         if token.aes.get() {
                             // SAFETY: we access correct union variant
                             let aes_enc = unsafe { &enc.inner.aes };
@@ -455,7 +455,7 @@ macro_rules! define_aes_impl {
                     not(aes_backend = "soft"),
                 ))]
                 pub(super) aes: backends::x86_aes::$name,
-                #[cfg(all(target_arch = "aarch64", not(aes_backend = "soft")))]
+                #[cfg(all(target_arch = "aarch64", not(miri), not(aes_backend = "soft")))]
                 pub(super) aes: backends::aarch64_aes::$name,
                 pub(super) soft: backends::soft::$name,
             }
@@ -467,7 +467,7 @@ macro_rules! define_aes_impl {
                     not(aes_backend = "soft"),
                 ))]
                 pub(super) aes: backends::x86_aes::$name_enc,
-                #[cfg(all(target_arch = "aarch64", not(aes_backend = "soft")))]
+                #[cfg(all(target_arch = "aarch64", not(miri), not(aes_backend = "soft")))]
                 pub(super) aes: backends::aarch64_aes::$name_enc,
                 pub(super) soft: backends::soft::$name,
             }
@@ -479,7 +479,7 @@ macro_rules! define_aes_impl {
                     not(aes_backend = "soft"),
                 ))]
                 pub(super) aes: backends::x86_aes::$name_dec,
-                #[cfg(all(target_arch = "aarch64", not(aes_backend = "soft")))]
+                #[cfg(all(target_arch = "aarch64", not(miri), not(aes_backend = "soft")))]
                 pub(super) aes: backends::aarch64_aes::$name_dec,
                 pub(super) soft: backends::soft::$name,
             }

--- a/aes/tests/mod.rs
+++ b/aes/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Test vectors are from NESSIE:
 //! https://www.cosic.esat.kuleuven.be/nessie/testvectors/
+#![cfg(not(miri))]
 
 cipher::block_cipher_test!(aes128, aes::Aes128);
 cipher::block_cipher_test!(aes192, aes::Aes192);


### PR DESCRIPTION
See this [comment](https://github.com/RustCrypto/utils/pull/1513#issuecomment-5451294399).

Closes #585