### PR TITLE
Release aes v0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "cipher",
  "cpubits",

--- a/aes/CHANGELOG.md
+++ b/aes/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.3 (UNRELEASED)
+## 0.9.3 (2026-08-28)
 ### Changed
 - MSRV bumped to 1.89 ([#580])
 - VAES-256 and VAES-512 backends on x86 targets are now supported by default ([#580])

--- a/aes/Cargo.toml
+++ b/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.9.2"
+version = "0.9.3"
 description = "Pure Rust implementation of the Advanced Encryption Standard (a.k.a. Rijndael)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- MSRV bumped to 1.89 ([#580])
- VAES-256 and VAES-512 backends on x86 targets are now supported by default ([#580])
- Disable `aarch64_aes` backend on Miri ([#586])

### Removed
- `aes_backend = "avx256"` and `aes_backend = "avx512"` configuration flags ([#580])

[#580]: https://github.com/RustCrypto/block-ciphers/pull/580
[#586]: https://github.com/RustCrypto/block-ciphers/pull/586